### PR TITLE
Refactor the code to make task functions simple functions

### DIFF
--- a/cabbage/task_worker.py
+++ b/cabbage/task_worker.py
@@ -28,7 +28,7 @@ class Worker:
                 break
 
             logger.debug("Waiting")
-            select.select(rlist=[connection], wlist=[], xlist=[], timeout=timeout)
+            select.select([connection], [], [], timeout)
 
     def process_tasks(self) -> None:
         for task_row in self._task_manager.get_tasks(self._queue):  # pragma: no branch
@@ -58,13 +58,12 @@ class Worker:
 
         pk = task_row.id
 
-        task_run = tasks.TaskRun(task=task, id=pk, lock=task_row.targeted_object)
         kwargs = task_row.args
 
         description = f"{task.queue}.{task.name}.{pk}({kwargs})"
         logger.info(f"Start - {description}")
         try:
-            task_run.run(**kwargs)
+            task.func(**kwargs)
         except Exception as e:
             logger.exception(f"Error - {description}")
             raise exceptions.TaskError() from e

--- a/cabbage_demo/__main__.py
+++ b/cabbage_demo/__main__.py
@@ -8,28 +8,20 @@ task_manager = cabbage.TaskManager()
 
 
 @task_manager.task(queue="sums")
-def sum(task_run, a, b):
-    with open(f"{task_run.task.name}-{task_run.id}", "w") as f:
-        f.write(f"{a + b}")
+def sum(a, b):
+    print(a + b)
 
 
 @task_manager.task(queue="sums")
-def sleep(task_run, i):
+def sleep(i):
     import time
 
     time.sleep(i)
 
 
 @task_manager.task(queue="sums")
-def sum_plus_one(task_run, a, b):
-    with open(f"{task_run.task.name}-{task_run.id}", "w") as f:
-        f.write(f"{a + b + 1}")
-
-
-@cabbage.Task(manager=task_manager, queue="products")
-def product(task_run, a, b):
-    with open(f"{task_run.task.name}-{task_run.id}", "w") as f:
-        f.write(f"{a * b}")
+def sum_plus_one(a, b):
+    print(a + b + 1)
 
 
 def client():

--- a/tests/acceptance/test_nominal.py
+++ b/tests/acceptance/test_nominal.py
@@ -10,23 +10,23 @@ def test_nominal(connection, kill_own_pid):
     product_results = []
 
     @task_manager.task(queue="sum_queue")
-    def sum_task(task_run, a, b):  # pytest: disable=unused-argument
+    def sum_task(a, b):  # pytest: disable=unused-argument
         sum_results.append(a + b)
 
     @task_manager.task(queue="sum_queue")
-    def increment_task(task_run, a):  # pytest: disable=unused-argument
+    def increment_task(a):  # pytest: disable=unused-argument
         sum_results.append(a + 1)
 
     @task_manager.task(queue="sum_queue")
-    def stop_sum(task_run):
+    def stop_sum():
         kill_own_pid(signal.SIGINT)
 
     @task_manager.task(queue="product_queue")
-    def product_task(task_run, a, b):  # pytest: disable=unused-argument
+    def product_task(a, b):  # pytest: disable=unused-argument
         product_results.append(a * b)
 
     @task_manager.task(queue="product_queue")
-    def stop_product(task_run):
+    def stop_product():
         kill_own_pid(signal.SIGTERM)
 
     sum_task.defer(a=5, b=7)

--- a/tests/unit/test_task_worker.py
+++ b/tests/unit/test_task_worker.py
@@ -25,9 +25,7 @@ def test_run(manager, mocker):
     worker.run(timeout=42)
 
     listen_queue.assert_called_with(connection=manager.connection, queue="marsupilami")
-    select.assert_called_with(
-        rlist=[manager.connection], wlist=[], xlist=[], timeout=42
-    )
+    select.assert_called_with([manager.connection], [], [], 42)
 
 
 def test_process_tasks(mocker, manager):
@@ -76,11 +74,10 @@ def test_process_tasks(mocker, manager):
 def test_run_task(manager):
     result = []
 
-    def job(task_run, a, b):  # pylint: disable=unused-argument
+    def job(a, b):  # pylint: disable=unused-argument
         result.append(a + b)
 
-    task = tasks.Task(manager=manager, queue="yay", name="job")
-    task.func = job
+    task = tasks.Task(job, manager=manager, queue="yay", name="job")
 
     manager.tasks = {"job": task}
 
@@ -94,10 +91,10 @@ def test_run_task(manager):
 
 
 def test_run_task_error(manager):
-    def job(task_run, a, b):  # pylint: disable=unused-argument
+    def job(a, b):  # pylint: disable=unused-argument
         raise ValueError("nope")
 
-    task = tasks.Task(manager=manager, queue="yay", name="job")
+    task = tasks.Task(job, manager=manager, queue="yay", name="job")
     task.func = job
 
     manager.tasks = {"job": task}


### PR DESCRIPTION
This PR makes the `manager.task()` method a true decorator by not altering the decorated function  (except the addition of a `defer()` method to it to replicate the previous behavior).

What this allows is the ability to start decorating existing functions without modifying their signature (no `task_run` anymore) and leave them unit testable without relying on the internals of `cabbage`.

This code came up when trying to address #3 and I think if we go the route of this PR this makes the implementation of test specific tools in `cabbage` mostly unnecessary.

To sum it up, we can now have something like this:

```python
from cabbage import TaskManager

manager = TaskManager()


@manager.task(queue="default")
def add(a, b):
    return a + b


add(1, 2)  # 3
```