### PR TITLE
WIP Add a way to specify a scheduled time for a task

### DIFF
--- a/cabbage/postgres.py
+++ b/cabbage/postgres.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Iterator, NamedTuple, Optional
 
 import psycopg2
@@ -28,13 +29,14 @@ def launch_task(
     name: str,
     lock: str,
     kwargs: types.JSONDict,
+    scheduled_time: datetime,
 ) -> int:
     with connection.cursor() as cursor:
         cursor.execute(
-            """INSERT INTO tasks (queue_id, task_type, targeted_object, args)
-               SELECT id, %s, %s, %s FROM queues WHERE queue_name=%s
+            """INSERT INTO tasks (queue_id, task_type, targeted_object, args, scheduled_at)
+               SELECT id, %s, %s, %s, %s FROM queues WHERE queue_name=%s
                RETURNING id;""",
-            (name, lock, kwargs, queue),
+            (name, lock, kwargs, scheduled_time, queue),
         )
         row = cursor.fetchone()
 

--- a/cabbage_demo/__main__.py
+++ b/cabbage_demo/__main__.py
@@ -1,6 +1,8 @@
 import logging
 import sys
 
+import pendulum
+
 import cabbage
 
 logger = logging.getLogger(__name__)
@@ -33,6 +35,7 @@ def client():
     sleep.defer(lock="a", i=2)
     sleep.defer(lock="a", i=3)
     sleep.defer(lock="a", i=4)
+    sleep.schedule_at(pendulum.now().add(seconds=15), i=2)
 
 
 def main():

--- a/init.sql
+++ b/init.sql
@@ -71,7 +71,8 @@ CREATE TABLE public.tasks (
     task_type character varying(32) NOT NULL,
     targeted_object text,
     args jsonb DEFAULT '{}' NOT NULL,
-    status public.task_status DEFAULT 'todo'::public.task_status NOT NULL
+    status public.task_status DEFAULT 'todo'::public.task_status NOT NULL,
+    scheduled_at timestamp with time zone NOT NULL
 );
 
 
@@ -94,7 +95,7 @@ BEGIN
 		SELECT tasks.*
 			FROM tasks
 			LEFT JOIN task_locks ON task_locks.object = tasks.targeted_object
-			WHERE queue_id = target_queue_id AND task_locks.object IS NULL AND status = 'todo'
+			WHERE queue_id = target_queue_id AND task_locks.object IS NULL AND status = 'todo' AND scheduled_at <= now()
 			FOR UPDATE OF tasks SKIP LOCKED LIMIT 1
 	), lock_object AS (
 		INSERT INTO task_locks

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ zip_safe = True
 include_package_data = True
 packages = find:
 install_requires =
+    pendulum~=2.0
     psycopg2
 
 [options.extras_require]


### PR DESCRIPTION
This PR adds support for specifying the time a task must be executed.

This is done via a `schedule_at()` method which takes a `datetime` object as its first parameter.

```python
from datetime import datetime
from cabbage import TaskManager

manager = TaskManager()


@manager.task(queue="default")
def add(a, b):
    return a + b


add.schedule_at(datetime.now(), a=1, b=2)
```

If the datetime passed to `schedule_at()` is naive it assumes the local timezone.

This is still a work in progress because I want to add a way to delay a task by providing a duration. Early feedback is still appreciated though :-)

Note that this PR is based on #15 

Closes #8