### PR TITLE
Fix coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   - tox --notest -e $TOX_ENV
 
 script:
-  - tox -e $TOX_ENV
+  - tox -e $TOX_ENV -- --cov-append
 
 after_success:
 - codecov

--- a/tox.ini
+++ b/tox.ini
@@ -10,9 +10,9 @@ passenv =
     {integration,acceptance}-tests: PG*
 commands =
     pip freeze -l
-    unit-tests: pytest tests/unit
-    integration-tests: pytest tests/integration
-    acceptance-tests: pytest tests/acceptance
+    unit-tests: pytest tests/unit {posargs}
+    integration-tests: pytest tests/integration {posargs}
+    acceptance-tests: pytest tests/acceptance {posargs}
 
 [testenv:lint]
 extras =


### PR DESCRIPTION
Closes #18 

As far as I can tell, the problem is that we're computing coverage
independently in the unit, integration and acceptance tests.

Different solutions include:
- Always putting the --cov-append flag, but it might lead to erroneous
reports
- Switching matrix to individual runs. It could be interesting to
identify erroneous builds quicker but at the price of setupping the VM
more times (and it seems it's actually the longest part of the CI)
- Making it so that --cov-append is only passed in the context of the
CI, which is what we're doing here.