### PR TITLE
Add the notion of "JobStore"

### DIFF
--- a/cabbage/__init__.py
+++ b/cabbage/__init__.py
@@ -1,4 +1,5 @@
 from cabbage.task_worker import Worker
 from cabbage.tasks import Task, TaskManager
+from cabbage.postgres import PostgresJobStore
 
-__all__ = ["Worker", "Task", "TaskManager"]
+__all__ = ["Worker", "Task", "TaskManager", "PostgresJobStore"]

--- a/cabbage/__init__.py
+++ b/cabbage/__init__.py
@@ -1,5 +1,5 @@
+from cabbage.postgres import PostgresJobStore
 from cabbage.task_worker import Worker
 from cabbage.tasks import Task, TaskManager
-from cabbage.postgres import PostgresJobStore
 
 __all__ = ["Worker", "Task", "TaskManager", "PostgresJobStore"]

--- a/cabbage/jobs.py
+++ b/cabbage/jobs.py
@@ -1,0 +1,19 @@
+from enum import Enum
+from typing import NamedTuple
+
+from cabbage import types
+
+
+class Status(Enum):
+    TODO = "todo"
+    DOING = "doing"
+    DONE = "done"
+    ERROR = "error"
+
+
+class Job(NamedTuple):
+    id: int
+    task_name: str
+    queue: str
+    kwargs: types.JSONDict
+    lock: str

--- a/cabbage/postgres.py
+++ b/cabbage/postgres.py
@@ -111,8 +111,8 @@ init_pg_extensions()
 
 
 class PostgresJobStore(store.JobStore):
-    def __init__(self, connection_params: Dict[str, Any] = None):
-        self.connection = get_connection(**(connection_params or {}))
+    def __init__(self, connection: Optional[psycopg2._psycopg.connection] = None):
+        self.connection = connection or get_connection()
 
     def register_queue(self, queue: str) -> Optional[int]:
         return register_queue(connection=self.connection, queue=queue)

--- a/cabbage/postgres.py
+++ b/cabbage/postgres.py
@@ -1,5 +1,5 @@
 import select
-from typing import Any, Dict, Iterator, Optional
+from typing import Iterator, Optional
 
 import psycopg2
 from psycopg2 import extras, sql

--- a/cabbage/postgres.py
+++ b/cabbage/postgres.py
@@ -1,17 +1,11 @@
-from typing import Iterator, NamedTuple, Optional
+import select
+from typing import Any, Dict, Iterator, Optional
 
 import psycopg2
 from psycopg2 import extras, sql
 from psycopg2.extras import RealDictCursor
 
-from cabbage import exceptions, types
-
-
-class TaskRow(NamedTuple):
-    id: int
-    task_type: str
-    args: types.JSONDict
-    targeted_object: str
+from cabbage import exceptions, jobs, store, types
 
 
 def get_connection(**kwargs) -> psycopg2._psycopg.connection:
@@ -47,7 +41,7 @@ def launch_task(
 
 def get_tasks(
     connection: psycopg2._psycopg.connection, queue: str
-) -> Iterator[TaskRow]:
+) -> Iterator[jobs.Job]:
     with connection.cursor(cursor_factory=RealDictCursor) as cursor:
         while True:
             cursor.execute(
@@ -63,7 +57,13 @@ def get_tasks(
             if row["id"] is None:
                 return
 
-            yield TaskRow(**row)
+            yield jobs.Job(
+                id=row["id"],
+                lock=row["targeted_object"],
+                task_name=row["task_type"],
+                kwargs=row["args"],
+                queue=queue,
+            )
 
 
 def finish_task(
@@ -103,4 +103,37 @@ def listen_queue(connection: psycopg2._psycopg.connection, queue: str) -> None:
         )
 
 
+def wait_for_jobs(connection: psycopg2._psycopg.connection, timeout: int):
+    select.select([connection], [], [], timeout)
+
+
 init_pg_extensions()
+
+
+class PostgresJobStore(store.JobStore):
+    def __init__(self, connection_params: Dict[str, Any] = None):
+        self.connection = get_connection(**(connection_params or {}))
+
+    def register_queue(self, queue: str) -> Optional[int]:
+        return register_queue(connection=self.connection, queue=queue)
+
+    def launch_task(
+        self, queue: str, name: str, lock: str, kwargs: types.JSONDict
+    ) -> int:
+        return launch_task(
+            connection=self.connection, queue=queue, name=name, lock=lock, kwargs=kwargs
+        )
+
+    def get_tasks(self, queue: str) -> Iterator[jobs.Job]:
+        return get_tasks(connection=self.connection, queue=queue)
+
+    def finish_task(self, job: jobs.Job, status: jobs.Status) -> None:
+        return finish_task(
+            connection=self.connection, task_id=job.id, status=status.value
+        )
+
+    def listen_for_jobs(self, queue: str):
+        listen_queue(connection=self.connection, queue=queue)
+
+    def wait_for_jobs(self, timeout: int):
+        wait_for_jobs(connection=self.connection, timeout=timeout)

--- a/cabbage/store.py
+++ b/cabbage/store.py
@@ -1,6 +1,21 @@
-from typing import Iterator, Optional
+import importlib
+from typing import Iterator, Optional, Type
 
 from cabbage import jobs, types
+
+
+def load_store_from_path(path: str) -> Type["JobStore"]:
+    """
+    Import the JobStore subclass at the given path, return the class.
+    """
+    path, name = path.rsplit(".", 1)
+    module = importlib.import_module(path)
+
+    job_store_class = getattr(module, name)
+
+    assert issubclass(job_store_class, JobStore)
+
+    return job_store_class
 
 
 class JobStore:

--- a/cabbage/store.py
+++ b/cabbage/store.py
@@ -1,0 +1,25 @@
+from typing import Iterator, Optional
+
+from cabbage import jobs, types
+
+
+class JobStore:
+    def register_queue(self, queue: str) -> Optional[int]:
+        raise NotImplementedError
+
+    def launch_task(
+        self, queue: str, name: str, lock: str, kwargs: types.JSONDict
+    ) -> int:
+        raise NotImplementedError
+
+    def get_tasks(self, queue: str) -> Iterator[jobs.Job]:
+        raise NotImplementedError
+
+    def finish_task(self, job: jobs.Job, status: jobs.Status) -> None:
+        raise NotImplementedError
+
+    def listen_for_jobs(self, queue: str):
+        raise NotImplementedError
+
+    def wait_for_jobs(self, timeout: int):
+        raise NotImplementedError

--- a/cabbage/task_worker.py
+++ b/cabbage/task_worker.py
@@ -25,19 +25,21 @@ class Worker:
 
         self._job_store.listen_for_jobs(queue=self._queue)
 
-        while True:
-            with signals.on_stop(self.stop):
+        with signals.on_stop(self.stop):
+            while True:
                 self.process_tasks()
 
-            if self._stop_requested:
-                logger.debug(
-                    "Finished running task at the end of the batch",
-                    extra={"action": "stopped_end_batch"},
-                )
-                break
+                if self._stop_requested:
+                    logger.debug(
+                        "Finished running task at the end of the batch",
+                        extra={"action": "stopped_end_batch"},
+                    )
+                    break
 
-            logger.debug("Waiting for new tasks", extra={"action": "waiting_for_tasks"})
-            self._job_store.wait_for_jobs(timeout=timeout)
+                logger.debug(
+                    "Waiting for new tasks", extra={"action": "waiting_for_tasks"}
+                )
+                self._job_store.wait_for_jobs(timeout=timeout)
 
     def process_tasks(self) -> None:
         for job in self._job_store.get_tasks(self._queue):  # pragma: no branch

--- a/cabbage/task_worker.py
+++ b/cabbage/task_worker.py
@@ -1,8 +1,7 @@
 import logging
-import select
 import time
 
-from cabbage import exceptions, postgres, signals, tasks, types
+from cabbage import exceptions, jobs, signals, store, tasks, types
 
 logger = logging.getLogger(__name__)
 
@@ -18,10 +17,13 @@ class Worker:
         # Handling the info about the currently running task.
         self.log_context: types.JSONDict = {}
 
-    def run(self, timeout: int = SOCKET_TIMEOUT) -> None:
-        connection = self._task_manager.connection
+    @property
+    def _job_store(self) -> store.JobStore:
+        return self._task_manager.job_store
 
-        postgres.listen_queue(connection=connection, queue=self._queue)
+    def run(self, timeout: int = SOCKET_TIMEOUT) -> None:
+
+        self._job_store.listen_for_jobs(queue=self._queue)
 
         while True:
             with signals.on_stop(self.stop):
@@ -35,25 +37,26 @@ class Worker:
                 break
 
             logger.debug("Waiting for new tasks", extra={"action": "waiting_for_tasks"})
-            select.select([connection], [], [], timeout)
+            self._job_store.wait_for_jobs(timeout=timeout)
 
     def process_tasks(self) -> None:
-        for task_row in self._task_manager.get_tasks(self._queue):  # pragma: no branch
-            assert isinstance(task_row.id, int)
-            log_context = {"row": task_row._asdict(), "queue": self._queue}
+        for job in self._job_store.get_tasks(self._queue):  # pragma: no branch
+            assert isinstance(job.id, int)
+
+            log_context = {"row": job._asdict(), "queue": self._queue}
             logger.debug(
                 "Loaded task row, about to start task",
                 extra={"action": "loaded_task_row", **log_context},
             )
 
-            status = "error"
+            status = jobs.Status.ERROR
             try:
-                self.run_task(task_row=task_row)
-                status = "done"
+                self.run_task(job=job)
+                status = jobs.Status.DONE
             except exceptions.TaskError:
                 pass
             finally:
-                self._task_manager.finish_task(task_row, status=status)
+                self._job_store.finish_task(job=job, status=status)
                 logger.debug(
                     "Acknowledged task row completion",
                     extra={"action": "finish_task", "status": status, **log_context},
@@ -62,16 +65,16 @@ class Worker:
             if self._stop_requested:
                 break
 
-    def run_task(self, task_row: postgres.TaskRow) -> None:
-        task_name = task_row.task_type
+    def run_task(self, job: jobs.Job) -> None:
+        task_name = job.task_name
         try:
             task = self._task_manager.tasks[task_name]
         except KeyError:
-            raise exceptions.TaskNotFound(task_row)
+            raise exceptions.TaskNotFound(job)
 
-        pk = task_row.id
+        pk = job.id
 
-        kwargs = task_row.args
+        kwargs = job.kwargs
 
         # We store the log context in self. This way, when requesting
         # a stop, we can get details on the currently running task

--- a/cabbage/tasks.py
+++ b/cabbage/tasks.py
@@ -1,5 +1,4 @@
 import functools
-import importlib
 import logging
 import uuid
 from typing import Any, Callable, Dict, Optional, Set
@@ -46,30 +45,13 @@ class Task:
 
 
 class TaskManager:
-    def __init__(self, job_store: store.JobStore = None):
+    def __init__(self, job_store: Optional[store.JobStore] = None):
         if job_store is None:
             job_store = postgres.PostgresJobStore()
 
         self.job_store = job_store
         self.tasks: Dict[str, Task] = {}
         self.queues: Set[str] = set()
-
-    @classmethod
-    def with_job_store_class(cls, path: str, **kwargs) -> "TaskManager":
-        """
-        Import the JobStore subclass at the given path, instanciates it
-        and returns a TaskManager with this JobStore object.
-        """
-        path, name = path.rsplit(".", 1)
-        module = importlib.import_module(path)
-
-        job_store_class = getattr(module, name)
-
-        assert issubclass(job_store_class, store.JobStore)
-
-        job_store = job_store_class(**kwargs)
-
-        return cls(job_store=job_store)
 
     def task(
         self,

--- a/cabbage/tasks.py
+++ b/cabbage/tasks.py
@@ -2,7 +2,7 @@ import functools
 import importlib
 import logging
 import uuid
-from typing import Callable, Dict, Optional, Set
+from typing import Any, Callable, Dict, Optional, Set
 
 from cabbage import postgres, store, types
 

--- a/cabbage/tasks.py
+++ b/cabbage/tasks.py
@@ -35,10 +35,12 @@ class Task:
             "Scheduled task",
             extra={
                 "action": "task_defer",
-                "name": self.name,
-                "queue": self.queue,
-                "kwargs": kwargs,
-                "id": task_id,
+                "job": {
+                    "name": self.name,
+                    "queue": self.queue,
+                    "kwargs": kwargs,
+                    "id": task_id,
+                },
             },
         )
 

--- a/cabbage/tasks.py
+++ b/cabbage/tasks.py
@@ -1,9 +1,9 @@
 import functools
 import logging
 import uuid
-from typing import Any, Callable, Dict, Iterator, Optional, Set
+from typing import Callable, Dict, Optional, Set
 
-from cabbage import postgres, types
+from cabbage import postgres, store, types
 
 logger = logging.getLogger(__name__)
 
@@ -27,12 +27,8 @@ class Task:
 
     def defer(self, lock: str = None, **kwargs: types.JSONValue) -> None:
         lock = lock or f"{uuid.uuid4()}"
-        task_id = postgres.launch_task(
-            self.manager.connection,
-            queue=self.queue,
-            name=self.name,
-            lock=lock,
-            kwargs=kwargs,
+        task_id = self.manager.job_store.launch_task(
+            queue=self.queue, name=self.name, lock=lock, kwargs=kwargs
         )
         logger.info(
             "Scheduled task",
@@ -47,11 +43,11 @@ class Task:
 
 
 class TaskManager:
-    def __init__(self, connection: Any = None) -> None:
-        if connection is None:
-            connection = postgres.get_connection()
+    def __init__(self, job_store: store.JobStore = None) -> None:
+        if job_store is None:
+            job_store = postgres.PostgresJobStore()
 
-        self.connection = connection
+        self.job_store = job_store
         self.tasks: Dict[str, Task] = {}
         self.queues: Set[str] = set()
 
@@ -85,11 +81,5 @@ class TaskManager:
                 "Creating queue (if not already existing)",
                 extra={"action": "create_queue", "queue": task.queue},
             )
-            postgres.register_queue(self.connection, task.queue)
+            self.job_store.register_queue(task.queue)
             self.queues.add(task.queue)
-
-    def get_tasks(self, queue: str) -> Iterator[postgres.TaskRow]:
-        return postgres.get_tasks(self.connection, queue)
-
-    def finish_task(self, task_row: postgres.TaskRow, status: str) -> None:
-        return postgres.finish_task(self.connection, task_row.id, status)

--- a/cabbage/tasks.py
+++ b/cabbage/tasks.py
@@ -1,4 +1,5 @@
 import functools
+import importlib
 import logging
 import uuid
 from typing import Callable, Dict, Optional, Set
@@ -43,13 +44,30 @@ class Task:
 
 
 class TaskManager:
-    def __init__(self, job_store: store.JobStore = None) -> None:
+    def __init__(self, job_store: store.JobStore = None):
         if job_store is None:
             job_store = postgres.PostgresJobStore()
 
         self.job_store = job_store
         self.tasks: Dict[str, Task] = {}
         self.queues: Set[str] = set()
+
+    @classmethod
+    def with_job_store_class(cls, path: str, **kwargs) -> "TaskManager":
+        """
+        Import the JobStore subclass at the given path, instanciates it
+        and returns a TaskManager with this JobStore object.
+        """
+        path, name = path.rsplit(".", 1)
+        module = importlib.import_module(path)
+
+        job_store_class = getattr(module, name)
+
+        assert issubclass(job_store_class, store.JobStore)
+
+        job_store = job_store_class(**kwargs)
+
+        return cls(job_store=job_store)
 
     def task(
         self,

--- a/cabbage/testing.py
+++ b/cabbage/testing.py
@@ -31,7 +31,6 @@ class InMemoryJobStore(store.JobStore):
             yield job
 
     def finish_task(self, job: jobs.Job, status: jobs.Status) -> None:
-        print(self.jobs[job.queue])
         j = self.jobs[job.queue].pop(0)
         assert job == j, (job, j)
         self.finished_jobs.append((job, status))

--- a/cabbage/testing.py
+++ b/cabbage/testing.py
@@ -1,0 +1,43 @@
+from itertools import count
+from typing import Dict, Iterator, List, Optional
+
+from cabbage import jobs, store, types
+
+
+class InMemoryJobStore(store.JobStore):
+    def __init__(self):
+        self.jobs: Dict[str, List[jobs.Job]] = {}
+        self.queues_counter = count()
+        self.job_counter = count()
+        self.listening_queues = set()
+        self.waited = []
+        self.finished_jobs = []
+
+    def register_queue(self, queue: str) -> Optional[int]:
+        self.jobs[queue] = []
+        return next(self.queues_counter)
+
+    def launch_task(
+        self, queue: str, name: str, lock: str, kwargs: types.JSONDict
+    ) -> int:
+        id = next(self.job_counter)
+        self.jobs[queue].append(
+            jobs.Job(id=id, task_name=name, lock=lock, kwargs=kwargs, queue=queue)
+        )
+        return id
+
+    def get_tasks(self, queue: str) -> Iterator[jobs.Job]:
+        for job in list(self.jobs[queue]):
+            yield job
+
+    def finish_task(self, job: jobs.Job, status: jobs.Status) -> None:
+        print(self.jobs[job.queue])
+        j = self.jobs[job.queue].pop(0)
+        assert job == j, (job, j)
+        self.finished_jobs.append((job, status))
+
+    def listen_for_jobs(self, queue: str):
+        self.listening_queues.add(queue)
+
+    def wait_for_jobs(self, timeout: int):
+        self.waited.append(timeout)

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,3 +58,7 @@ addopts = --cov-report term-missing --cov-branch --cov-report html --cov-report 
 
 [mypy-setuptools.*,psycopg2.*]
 ignore_missing_imports = True
+
+[coverage:report]
+exclude_lines =
+    raise NotImplementedError

--- a/tests/acceptance/test_nominal.py
+++ b/tests/acceptance/test_nominal.py
@@ -5,9 +5,11 @@ import time
 import cabbage
 
 
-def test_nominal(connection, kill_own_pid):
+def test_nominal(connection, kill_own_pid, caplog):
     job_store = cabbage.PostgresJobStore(connection=connection)
     task_manager = cabbage.TaskManager(job_store=job_store)
+
+    caplog.set_level("DEBUG")
 
     sum_results = []
     product_results = []

--- a/tests/acceptance/test_nominal.py
+++ b/tests/acceptance/test_nominal.py
@@ -6,7 +6,8 @@ import cabbage
 
 
 def test_nominal(connection, kill_own_pid):
-    task_manager = cabbage.TaskManager(connection=connection)
+    job_store = cabbage.PostgresJobStore(connection=connection)
+    task_manager = cabbage.TaskManager(job_store=job_store)
 
     sum_results = []
     product_results = []

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -1,0 +1,7 @@
+from cabbage import store, testing
+
+
+def test_load_store_from_path():
+    store_class = store.load_store_from_path("cabbage.testing.InMemoryJobStore")
+
+    assert store_class is testing.InMemoryJobStore

--- a/tests/unit/test_task_worker.py
+++ b/tests/unit/test_task_worker.py
@@ -83,7 +83,17 @@ def test_process_tasks(mocker, task_manager, job_factory):
     ]
 
 
-def test_run_task(manager):
+def test_process_tasks_until_no_more_jobs(mocker, task_manager, job_factory):
+    job = job_factory(id=42)
+    task_manager.job_store.jobs["queue"] = [job]
+
+    mocker.patch("cabbage.task_worker.Worker.run_task")
+
+    worker = task_worker.Worker(task_manager, "queue")
+    worker.process_tasks()
+
+    assert task_manager.job_store.finished_jobs == [(job, jobs.Status.DONE)]
+
 
 def test_run_task(task_manager):
     result = []

--- a/tests/unit/test_task_worker.py
+++ b/tests/unit/test_task_worker.py
@@ -1,11 +1,29 @@
 import pytest
 
-from cabbage import exceptions, postgres, task_worker, tasks
+from cabbage import exceptions, task_worker, tasks, testing, jobs
 
 
 @pytest.fixture
-def manager():
-    return tasks.TaskManager(connection=object())
+def manager(mocker):
+    return tasks.TaskManager(job_store=testing.InMemoryJobStore())
+
+
+@pytest.fixture
+def job_factory():
+    defaults = {
+        "id": 42,
+        "task_name": "bla",
+        "kwargs": {},
+        "lock": None,
+        "queue": "queue",
+    }
+
+    def factory(**kwargs):
+        final_kwargs = defaults.copy()
+        final_kwargs.update(kwargs)
+        return jobs.Job(**final_kwargs)
+
+    return factory
 
 
 def test_run(manager, mocker):
@@ -17,25 +35,24 @@ def test_run(manager, mocker):
                 self.stop(None, None)
             self.i += 1
 
-    listen_queue = mocker.patch("cabbage.postgres.listen_queue")
-    select = mocker.patch("select.select")
-
     worker = TestTaskWorker(task_manager=manager, queue="marsupilami")
 
     worker.run(timeout=42)
 
-    listen_queue.assert_called_with(connection=manager.connection, queue="marsupilami")
-    select.assert_called_with([manager.connection], [], [], 42)
+    manager.job_store.listening_queues == {"marsupilami"}
+    manager.job_store.waited == [42]
 
 
-def test_process_tasks(mocker, manager):
-    row1, row2, row3 = mocker.Mock(id=42), mocker.Mock(id=43), mocker.Mock(id=44)
-    mocker.patch("cabbage.postgres.get_tasks", return_value=[row1, row2, row3])
+def test_process_tasks(mocker, manager, job_factory):
+    job_1 = job_factory(id=42)
+    job_2 = job_factory(id=43)
+    job_3 = job_factory(id=44)
+    manager.job_store.jobs["queue"] = [job_1, job_2, job_3]
     worker = task_worker.Worker(manager, "queue")
 
     i = 0
 
-    def side_effect(task_row):
+    def side_effect(job):
         nonlocal i
         i += 1
         if i == 1:
@@ -51,23 +68,18 @@ def test_process_tasks(mocker, manager):
     call_task = mocker.patch(
         "cabbage.task_worker.Worker.run_task", side_effect=side_effect
     )
-    finish_task = mocker.patch("cabbage.postgres.finish_task")
-
     worker.process_tasks()
 
-    assert call_task.call_count == 3
-    assert finish_task.call_count == 3
-
     assert call_task.call_args_list == [
-        mocker.call(task_row=row1),
-        mocker.call(task_row=row2),
-        mocker.call(task_row=row3),
+        mocker.call(job=job_1),
+        mocker.call(job=job_2),
+        mocker.call(job=job_3),
     ]
 
-    assert finish_task.call_args_list == [
-        mocker.call(manager.connection, 42, "done"),
-        mocker.call(manager.connection, 43, "error"),
-        mocker.call(manager.connection, 44, "done"),
+    assert manager.job_store.finished_jobs == [
+        (job_1, jobs.Status.DONE),
+        (job_2, jobs.Status.ERROR),
+        (job_3, jobs.Status.DONE),
     ]
 
 
@@ -81,8 +93,8 @@ def test_run_task(manager):
 
     manager.tasks = {"job": task}
 
-    row = postgres.TaskRow(
-        id=16, args={"a": 9, "b": 3}, targeted_object="sherlock", task_type="job"
+    row = jobs.Job(
+        id=16, kwargs={"a": 9, "b": 3}, lock="sherlock", task_name="job", queue="yay"
     )
     worker = task_worker.Worker(manager, "yay")
     worker.run_task(row)
@@ -99,8 +111,8 @@ def test_run_task_error(manager):
 
     manager.tasks = {"job": task}
 
-    row = postgres.TaskRow(
-        id=16, args={"a": 9, "b": 3}, targeted_object="sherlock", task_type="job"
+    row = jobs.Job(
+        id=16, kwargs={"a": 9, "b": 3}, lock="sherlock", task_name="job", queue="yay"
     )
     worker = task_worker.Worker(manager, "yay")
     with pytest.raises(exceptions.TaskError):
@@ -108,8 +120,8 @@ def test_run_task_error(manager):
 
 
 def test_run_task_not_found(manager):
-    row = postgres.TaskRow(
-        id=16, args={"a": 9, "b": 3}, targeted_object="sherlock", task_type="job"
+    row = jobs.Job(
+        id=16, kwargs={"a": 9, "b": 3}, lock="sherlock", task_name="job", queue="yay"
     )
     worker = task_worker.Worker(manager, "yay")
     with pytest.raises(exceptions.TaskNotFound):

--- a/tests/unit/test_task_worker.py
+++ b/tests/unit/test_task_worker.py
@@ -1,6 +1,6 @@
 import pytest
 
-from cabbage import exceptions, task_worker, tasks, testing, jobs
+from cabbage import exceptions, jobs, task_worker, tasks, testing
 
 
 @pytest.fixture

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -105,11 +105,3 @@ def test_task_manager_default_connection(mocker):
     task_manager = tasks.TaskManager()
 
     assert isinstance(task_manager.job_store, postgres.PostgresJobStore)
-
-
-def test_task_manager_with_job_store_class():
-    task_manager = tasks.TaskManager.with_job_store_class(
-        "cabbage.testing.InMemoryJobStore"
-    )
-
-    assert isinstance(task_manager.job_store, testing.InMemoryJobStore)

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -105,3 +105,9 @@ def test_task_manager_default_connection(mocker):
     manager = tasks.TaskManager()
 
     assert isinstance(manager.job_store, postgres.PostgresJobStore)
+
+
+def test_task_manager_with_job_store_class():
+    manager = tasks.TaskManager.with_job_store_class("cabbage.testing.InMemoryJobStore")
+
+    assert isinstance(manager.job_store, testing.InMemoryJobStore)

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -55,7 +55,7 @@ def test_task_defer_no_lock(task_manager, mocker):
 
 
 def test_task_manager_task_explicit(task_manager, mocker):
-    @manager.task(queue="a", name="b")
+    @task_manager.task(queue="a", name="b")
     def wrapped():
         return "foo"
 

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -6,7 +6,7 @@ from cabbage import jobs, postgres, tasks, testing
 
 
 @pytest.fixture
-def manager(mocker):
+def task_manager(mocker):
     store = testing.InMemoryJobStore()
     return tasks.TaskManager(job_store=store)
 
@@ -15,26 +15,26 @@ def job():
     pass
 
 
-def test_task_init_with_no_name(manager):
-    task = tasks.Task(job, manager=manager, queue="queue")
+def test_task_init_with_no_name(task_manager):
+    task = tasks.Task(job, manager=task_manager, queue="queue")
 
     assert task.func is job
     assert task.name == "job"
 
 
-def test_task_init_explicit_name(manager, mocker):
-    task = tasks.Task(job, manager=manager, queue="queue", name="other")
+def test_task_init_explicit_name(task_manager, mocker):
+    task = tasks.Task(job, manager=task_manager, queue="queue", name="other")
 
     assert task.name == "other"
 
 
-def test_task_defer(manager, mocker):
-    manager.job_store.register_queue("queue")
-    task = tasks.Task(job, manager=manager, queue="queue", name="job")
+def test_task_defer(task_manager, mocker):
+    task_manager.job_store.register_queue("queue")
+    task = tasks.Task(job, manager=task_manager, queue="queue", name="job")
 
     task.defer(lock="sherlock", a="b", c=3)
 
-    assert manager.job_store.jobs["queue"] == [
+    assert task_manager.job_store.jobs["queue"] == [
         jobs.Job(
             id=0,
             queue="queue",
@@ -45,69 +45,71 @@ def test_task_defer(manager, mocker):
     ]
 
 
-def test_task_defer_no_lock(manager, mocker):
-    manager.job_store.register_queue("queue")
-    task = tasks.Task(job, manager=manager, queue="queue", name="job")
+def test_task_defer_no_lock(task_manager, mocker):
+    task_manager.job_store.register_queue("queue")
+    task = tasks.Task(job, manager=task_manager, queue="queue", name="job")
 
     task.defer(a="b", c=3)
 
-    assert uuid.UUID(manager.job_store.jobs["queue"][0].lock)
+    assert uuid.UUID(task_manager.job_store.jobs["queue"][0].lock)
 
 
-def test_task_manager_task_explicit(manager, mocker):
+def test_task_manager_task_explicit(task_manager, mocker):
     @manager.task(queue="a", name="b")
     def wrapped():
         return "foo"
 
     assert "foo" == wrapped()
-    assert "b" == manager.tasks["b"].name
-    assert "a" == manager.tasks["b"].queue
-    assert manager.tasks["b"] is wrapped
-    assert manager.tasks["b"].func is wrapped.__wrapped__
+    assert "b" == task_manager.tasks["b"].name
+    assert "a" == task_manager.tasks["b"].queue
+    assert task_manager.tasks["b"] is wrapped
+    assert task_manager.tasks["b"].func is wrapped.__wrapped__
 
 
-def test_task_manager_task_implicit(manager, mocker):
-    @manager.task
+def test_task_manager_task_implicit(task_manager, mocker):
+    @task_manager.task
     def wrapped():
         return "foo"
 
     assert "foo" == wrapped()
-    assert "wrapped" == manager.tasks["wrapped"].name
-    assert "default" == manager.tasks["wrapped"].queue
-    assert manager.tasks["wrapped"] is wrapped
-    assert manager.tasks["wrapped"].func is wrapped.__wrapped__
+    assert "wrapped" == task_manager.tasks["wrapped"].name
+    assert "default" == task_manager.tasks["wrapped"].queue
+    assert task_manager.tasks["wrapped"] is wrapped
+    assert task_manager.tasks["wrapped"].func is wrapped.__wrapped__
 
 
-def test_task_manager_register(manager, mocker):
-    task = tasks.Task(job, manager=manager, queue="queue", name="bla")
+def test_task_manager_register(task_manager, mocker):
+    task = tasks.Task(job, manager=task_manager, queue="queue", name="bla")
 
-    manager.register(task)
+    task_manager.register(task)
 
-    assert manager.queues == {"queue"}
-    assert manager.tasks == {"bla": task}
-    assert set(manager.job_store.jobs) == {"queue"}
+    assert task_manager.queues == {"queue"}
+    assert task_manager.tasks == {"bla": task}
+    assert set(task_manager.job_store.jobs) == {"queue"}
 
 
-def test_task_manager_register_queue_already_exists(manager, mocker):
-    manager.queues.add("queue")
-    task = tasks.Task(job, manager=manager, queue="queue", name="bla")
+def test_task_manager_register_queue_already_exists(task_manager, mocker):
+    task_manager.queues.add("queue")
+    task = tasks.Task(job, manager=task_manager, queue="queue", name="bla")
 
-    manager.register(task)
+    task_manager.register(task)
 
-    assert manager.queues == {"queue"}
-    assert manager.tasks == {"bla": task}
+    assert task_manager.queues == {"queue"}
+    assert task_manager.tasks == {"bla": task}
     # We never told the store that there were queues to register
-    assert not manager.job_store.jobs
+    assert not task_manager.job_store.jobs
 
 
 def test_task_manager_default_connection(mocker):
     mocker.patch("cabbage.postgres.get_connection")
-    manager = tasks.TaskManager()
+    task_manager = tasks.TaskManager()
 
-    assert isinstance(manager.job_store, postgres.PostgresJobStore)
+    assert isinstance(task_manager.job_store, postgres.PostgresJobStore)
 
 
 def test_task_manager_with_job_store_class():
-    manager = tasks.TaskManager.with_job_store_class("cabbage.testing.InMemoryJobStore")
+    task_manager = tasks.TaskManager.with_job_store_class(
+        "cabbage.testing.InMemoryJobStore"
+    )
 
-    assert isinstance(manager.job_store, testing.InMemoryJobStore)
+    assert isinstance(task_manager.job_store, testing.InMemoryJobStore)


### PR DESCRIPTION
Fixes #3 

This PR solves 2 related problems in one:

- Postgres was still highly coupled with several parts
- Because of that, it was harder to test (especially for cabbage users)

In order to implement #3, I added the notion of "JobStore", with 2 implemented stores:
- PostgresJobStore
- InMemoryJobStore (in a module named "testing")

This allows us to remove a lot of mocks in tests and all, which feels nice.

Only thing left to decide: how to test the PostgresJobStore that is a thin wrapper around equivalent functions in the module ?
- Unit-test it (and mock the function ?)
- Integration-test it (tests are going to look a lot like the tests of the functions it uses)
- Acceptance-test it (that's already done) (it's going to be the first lines that are neither covered by integration nor unit tests)
- Rewrite it. For example, put the code in the methods directly instead of the function. Not a fan, but we could discuss it.