### PR TITLE
Add support for job scheduling

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ packages = find:
 install_requires =
     psycopg2
     attrs
+    pendulum
 
 [options.extras_require]
 dev =
@@ -57,7 +58,7 @@ max-line-length = 88
 [tool:pytest]
 addopts = --cov-report term-missing --cov-branch --cov-report html --cov-report term --cov=cabbage -vv
 
-[mypy-setuptools.*,psycopg2.*]
+[mypy-setuptools.*,psycopg2.*,pendulum.*]
 ignore_missing_imports = True
 
 [coverage:report]

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -1,14 +1,32 @@
+import pendulum
 import pytest
 
-from cabbage import jobs, testing
-
-
-@pytest.fixture
-def job_store():
-    return testing.InMemoryJobStore()
+from cabbage import jobs
 
 
 def test_job_get_context(job_store):
+
+    job = jobs.Job(
+        id=12,
+        queue="marsupilami",
+        lock="sher",
+        task_name="mytask",
+        task_kwargs={"a": "b"},
+        scheduled_at=pendulum.datetime(2000, 1, 1, tz="Europe/Paris"),
+        job_store=job_store,
+    )
+
+    assert job.get_context() == {
+        "id": 12,
+        "queue": "marsupilami",
+        "lock": "sher",
+        "task_name": "mytask",
+        "task_kwargs": {"a": "b"},
+        "scheduled_at": "2000-01-01T00:00:00+01:00",
+    }
+
+
+def test_job_get_context_without_scheduled_at(job_store):
 
     job = jobs.Job(
         id=12,
@@ -25,6 +43,7 @@ def test_job_get_context(job_store):
         "lock": "sher",
         "task_name": "mytask",
         "task_kwargs": {"a": "b"},
+        "scheduled_at": None,
     }
 
 
@@ -53,3 +72,16 @@ def test_job_defer(job_store):
             job_store=job_store,
         )
     ]
+
+
+def test_job_scheduled_at_naive(job_store):
+    with pytest.raises(ValueError):
+        jobs.Job(
+            id=12,
+            queue="marsupilami",
+            lock="sher",
+            task_name="mytask",
+            task_kwargs={"a": "b"},
+            scheduled_at=pendulum.naive(2000, 1, 1),
+            job_store=job_store,
+        )

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -1,0 +1,19 @@
+import pendulum
+
+
+def test_get_jobs_scheduled_jobs(job_store, job_factory):
+    job_store.register_queue("foo")
+
+    job_store.launch_job(
+        job=job_factory(queue="foo", scheduled_at=pendulum.datetime(2000, 1, 1))
+    )
+    job_store.launch_job(
+        job=job_factory(queue="foo", scheduled_at=pendulum.now().subtract(minutes=1))
+    )
+    job_store.launch_job(
+        job=job_factory(queue="foo", scheduled_at=pendulum.datetime(2050, 1, 1))
+    )
+
+    jobs = list(job_store.get_jobs(queue="foo"))
+
+    assert {job.id for job in jobs} == {0, 1}

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -1,35 +1,6 @@
 import pytest
 
-from cabbage import exceptions, jobs, tasks, testing, worker
-
-
-@pytest.fixture
-def job_store():
-    return testing.InMemoryJobStore()
-
-
-@pytest.fixture
-def task_manager(job_store):
-    return tasks.TaskManager(job_store=job_store)
-
-
-@pytest.fixture
-def job_factory(job_store):
-    defaults = {
-        "id": 42,
-        "task_name": "bla",
-        "task_kwargs": {},
-        "lock": None,
-        "queue": "queue",
-        "job_store": job_store,
-    }
-
-    def factory(**kwargs):
-        final_kwargs = defaults.copy()
-        final_kwargs.update(kwargs)
-        return jobs.Job(**final_kwargs)
-
-    return factory
+from cabbage import exceptions, jobs, tasks, worker
 
 
 def test_run(task_manager, mocker):


### PR DESCRIPTION
This PR adds two new configuration option for jobs: `schedule_at` and `schedule_in`.

* `schedule_at` must be a timezone-aware datetime representing the moment the job must be executed.
* `schedule_in` must be a dictionnary representing the relative time the job must be executed at

```python
import pendulum
from cabbage import TaskManager

manager = TaskManager()


@manager.task(queue="default")
def add(a, b):
    return a + b

add.configure(schedule_at=pendulum.now().add(minutes=2)).defer(a=1, b=2)
add.configure(schedule_in={"minutes": 2}).defer(a=1, b=2)
```