### PR TITLE
Discover tasks

### DIFF
--- a/cabbage/exceptions.py
+++ b/cabbage/exceptions.py
@@ -6,6 +6,10 @@ class TaskNotFound(CabbageException):
     pass
 
 
+class NotATask(TaskNotFound):
+    pass
+
+
 class JobError(CabbageException):
     pass
 

--- a/cabbage/store.py
+++ b/cabbage/store.py
@@ -1,17 +1,13 @@
-import importlib
 from typing import Iterator, Optional, Type
 
-from cabbage import jobs
+from cabbage import jobs, utils
 
 
 def load_store_from_path(path: str) -> Type["JobStore"]:
     """
     Import the JobStore subclass at the given path, return the class.
     """
-    path, name = path.rsplit(".", 1)
-    module = importlib.import_module(path)
-
-    job_store_class = getattr(module, name)
+    job_store_class = utils.load_from_path(path)
 
     assert issubclass(job_store_class, JobStore)
 

--- a/cabbage/tasks.py
+++ b/cabbage/tasks.py
@@ -36,7 +36,8 @@ class Task:
         self.queue = queue
         self.manager = manager
         self.func: Callable = func
-        if name != self.full_path:
+        self.name: str
+        if name and name != self.full_path:
             logger.warning(
                 f"Task {name} at {self.full_path} has a name that doesn't match "
                 "its import path. Please make sure its module path is provided in "

--- a/cabbage/tasks.py
+++ b/cabbage/tasks.py
@@ -6,9 +6,22 @@ from typing import Any, Callable, Dict, Optional, Set
 
 import pendulum
 
-from cabbage import jobs, postgres, store, types
+from cabbage import exceptions, jobs, postgres, store, types, utils
 
 logger = logging.getLogger(__name__)
+
+
+def load_task(path: str) -> "Task":
+
+    try:
+        task = utils.load_from_path(path)
+    except ImportError:
+        raise exceptions.TaskNotFound(f"Task at {path} cannot be imported")
+
+    if not isinstance(task, Task):
+        raise exceptions.NotATask(f"Object at {path} is not a Task but: {type(task)}")
+
+    return task
 
 
 class Task:
@@ -23,10 +36,27 @@ class Task:
         self.queue = queue
         self.manager = manager
         self.func: Callable = func
-        self.name = name or self.func.__name__
+        if name != self.full_path:
+            logger.warning(
+                f"Task {name} at {self.full_path} has a name that doesn't match "
+                "its import path. Please make sure its module path is provided in "
+                "the worker's import_paths, or it won't run.",
+                extra={
+                    "action": "task_name_differ_from_path",
+                    "task_name": name,
+                    "task_path": self.full_path,
+                },
+            )
+            self.name = name
+        else:
+            self.name = self.full_path
 
     def __call__(self, **kwargs: types.JSONValue) -> None:
         return self.func(**kwargs)
+
+    @property
+    def full_path(self) -> str:
+        return f"{self.func.__module__}.{self.func.__name__}"
 
     def defer(self, **task_kwargs: types.JSONValue) -> int:
         job_id = self.configure().defer(**task_kwargs)

--- a/cabbage/utils.py
+++ b/cabbage/utils.py
@@ -1,0 +1,19 @@
+import importlib
+from typing import Any
+
+
+def load_from_path(path: str) -> Any:
+    """
+    Import and return then object at the given full python path.
+    """
+    if "." not in path:
+        raise ImportError(f"{path} is not a valid path")
+    path, name = path.rsplit(".", 1)
+    module = importlib.import_module(path)
+
+    try:
+        imported = getattr(module, name)
+    except AttributeError as exc:
+        raise ImportError from exc
+
+    return imported

--- a/cabbage/worker.py
+++ b/cabbage/worker.py
@@ -1,6 +1,6 @@
+import importlib
 import logging
 import time
-import importlib
 from typing import Iterable, Optional, Set
 
 from cabbage import exceptions, jobs, signals, store, tasks, types
@@ -18,7 +18,7 @@ def import_all(import_paths: Iterable[str]) -> None:
     for import_path in import_paths:
         logger.info(
             f"Importing module {import_path}",
-            extras={"action": "import_module", "module": import_path},
+            extra={"action": "import_module", "module_name": import_path},
         )
         importlib.import_module(import_path)
 
@@ -41,7 +41,7 @@ class Worker:
         # often is a side effect of the import of the module they're
         # defined in.
         if import_paths:
-            import_all(import_paths)
+            import_all(import_paths=import_paths)
 
     @property
     def _job_store(self) -> store.JobStore:
@@ -118,7 +118,8 @@ class Worker:
             raise
 
         logger.warning(
-            f"Task at {task_name} was not registered, it's been loaded dynamically."
+            f"Task at {task_name} was not registered, it's been loaded dynamically.",
+            extra={"action": "load_dynamic_task", "task_name": task_name},
         )
 
         self._task_manager.tasks[task_name] = task

--- a/cabbage/worker.py
+++ b/cabbage/worker.py
@@ -1,6 +1,7 @@
 import logging
 import time
-from typing import Optional
+import importlib
+from typing import Iterable, Optional, Set
 
 from cabbage import exceptions, jobs, signals, store, tasks, types
 
@@ -34,6 +35,8 @@ class Worker:
         self._stop_requested = False
         # Handling the info about the currently running task.
         self.log_context: types.JSONDict = {}
+        self.known_missing_tasks: Set[str] = set()
+
         # Import all the given paths. The registration of tasks
         # often is a side effect of the import of the module they're
         # defined in.
@@ -80,6 +83,11 @@ class Worker:
                 status = jobs.Status.DONE
             except exceptions.JobError:
                 pass
+            except exceptions.TaskNotFound as exc:
+                logger.exception(
+                    f"Task was not found: {exc}",
+                    extra={"action": "task_not_found", "exception": str(exc)},
+                )
             finally:
                 self._job_store.finish_job(job=job, status=status)
                 logger.debug(
@@ -90,12 +98,36 @@ class Worker:
             if self._stop_requested:
                 break
 
+    def load_task(self, task_name) -> tasks.Task:
+        if task_name in self.known_missing_tasks:
+            raise exceptions.TaskNotFound(
+                f"Cannot run job for task {task_name} previsouly not found"
+            )
+
+        try:
+            # Simple case: the task is already known
+            return self._task_manager.tasks[task_name]
+        except KeyError:
+            pass
+
+        # Will raise if not found or not a task
+        try:
+            task = tasks.load_task(task_name)
+        except exceptions.CabbageException:
+            self.known_missing_tasks.add(task_name)
+            raise
+
+        logger.warning(
+            f"Task at {task_name} was not registered, it's been loaded dynamically."
+        )
+
+        self._task_manager.tasks[task_name] = task
+        return task
+
     def run_job(self, job: jobs.Job) -> None:
         task_name = job.task_name
-        try:
-            task = self._task_manager.tasks[task_name]
-        except KeyError:
-            raise exceptions.TaskNotFound(job)
+
+        task = self.load_task(task_name=task_name)
 
         # We store the log context in self. This way, when requesting
         # a stop, we can get details on the currently running task

--- a/cabbage/worker.py
+++ b/cabbage/worker.py
@@ -10,13 +10,35 @@ logger = logging.getLogger(__name__)
 SOCKET_TIMEOUT = 5  # seconds
 
 
+def import_all(import_paths: Iterable[str]) -> None:
+    """
+    Given a list of paths, just import them all
+    """
+    for import_path in import_paths:
+        logger.info(
+            f"Importing module {import_path}",
+            extras={"action": "import_module", "module": import_path},
+        )
+        importlib.import_module(import_path)
+
+
 class Worker:
-    def __init__(self, task_manager: tasks.TaskManager, queue: str) -> None:
+    def __init__(
+        self,
+        task_manager: tasks.TaskManager,
+        queue: str,
+        import_paths: Optional[Iterable[str]] = None,
+    ):
         self._task_manager = task_manager
         self._queue = queue
         self._stop_requested = False
         # Handling the info about the currently running task.
         self.log_context: types.JSONDict = {}
+        # Import all the given paths. The registration of tasks
+        # often is a side effect of the import of the module they're
+        # defined in.
+        if import_paths:
+            import_all(import_paths)
 
     @property
     def _job_store(self) -> store.JobStore:

--- a/cabbage_demo/__main__.py
+++ b/cabbage_demo/__main__.py
@@ -2,37 +2,7 @@ import logging
 import sys
 
 import cabbage
-
-logger = logging.getLogger(__name__)
-task_manager = cabbage.TaskManager()
-
-
-@task_manager.task(queue="sums")
-def sum(a, b):
-    print(a + b)
-
-
-@task_manager.task(queue="sums")
-def sleep(i):
-    import time
-
-    time.sleep(i)
-
-
-@task_manager.task(queue="sums")
-def sum_plus_one(a, b):
-    print(a + b + 1)
-
-
-def client():
-    # sum.defer(a=3, b=5)
-    # sum.defer(a=5, b=7)
-    # sum.defer(a=5, b="a")
-    # sum_plus_one.defer(a=4, b=7)
-    # product.defer(a=2, b=8)
-    sleep.defer(lock="a", i=2)
-    sleep.defer(lock="a", i=3)
-    sleep.defer(lock="a", i=4)
+from cabbage_demo.cabbage_app import task_manager
 
 
 def main():
@@ -40,9 +10,15 @@ def main():
     process = sys.argv[1]
     if process == "worker":
         queue = sys.argv[2]
-        return cabbage.Worker(task_manager, queue).run()
+        worker = cabbage.Worker(
+            task_manager=task_manager, queue=queue, import_paths=["cabbage_demo.tasks"]
+        )
+        worker.run()
+
     else:
-        return client()
+        from cabbage_demo import client
+
+        return client.client()
 
 
 if __name__ == "__main__":

--- a/cabbage_demo/cabbage_app.py
+++ b/cabbage_demo/cabbage_app.py
@@ -1,0 +1,3 @@
+import cabbage
+
+task_manager = cabbage.TaskManager()

--- a/cabbage_demo/client.py
+++ b/cabbage_demo/client.py
@@ -1,0 +1,15 @@
+import logging
+
+from cabbage_demo import tasks
+
+logger = logging.getLogger(__name__)
+
+
+def client():
+    tasks.sum.defer(a=3, b=5)
+    tasks.sum.defer(a=5, b=7)
+    tasks.sum.defer(a=5, b="a")
+    tasks.sum_plus_one.defer(a=4, b=7)
+    tasks.sleep.configure(lock="a").defer(i=2)
+    tasks.sleep.configure(lock="a").defer(i=3)
+    tasks.sleep.configure(lock="a").defer(i=4)

--- a/cabbage_demo/tasks.py
+++ b/cabbage_demo/tasks.py
@@ -1,0 +1,18 @@
+from cabbage_demo.cabbage_app import task_manager
+
+
+@task_manager.task(queue="sums")
+def sum(a, b):
+    print(a + b)
+
+
+@task_manager.task(queue="sums")
+def sleep(i):
+    import time
+
+    time.sleep(i)
+
+
+@task_manager.task(queue="sums")
+def sum_plus_one(a, b):
+    print(a + b + 1)

--- a/init.sql
+++ b/init.sql
@@ -40,7 +40,7 @@ SET default_with_oids = false;
 CREATE TABLE public.cabbage_jobs (
     id integer NOT NULL,
     queue_id integer NOT NULL,
-    task_name character varying(32) NOT NULL,
+    task_name character varying(128) NOT NULL,
     lock text,
     args jsonb DEFAULT '{}' NOT NULL,
     status public.cabbage_job_status DEFAULT 'todo'::public.cabbage_job_status NOT NULL,

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -3,7 +3,7 @@ import uuid
 import pendulum
 import pytest
 
-from cabbage import jobs, postgres, tasks
+from cabbage import exceptions, jobs, postgres, tasks
 
 
 def task_func():
@@ -14,13 +14,19 @@ def test_task_init_with_no_name(task_manager):
     task = tasks.Task(task_func, manager=task_manager, queue="queue")
 
     assert task.func is task_func
-    assert task.name == "task_func"
+    assert task.name == "tests.unit.test_tasks.task_func"
 
 
-def test_task_init_explicit_name(task_manager, mocker):
+def test_task_init_explicit_name(task_manager, mocker, caplog):
     task = tasks.Task(task_func, manager=task_manager, queue="queue", name="other")
 
     assert task.name == "other"
+
+    assert [
+        record
+        for record in caplog.records
+        if record.action == "task_name_differ_from_path"
+    ]
 
 
 def test_task_defer(task_manager):
@@ -35,7 +41,7 @@ def test_task_defer(task_manager):
         jobs.Job(
             id=0,
             queue="queue",
-            task_name="task_func",
+            task_name="tests.unit.test_tasks.task_func",
             lock=lock,
             task_kwargs={"c": 3},
             job_store=task_manager.job_store,
@@ -105,11 +111,13 @@ def test_task_manager_task_implicit(task_manager, mocker):
     def wrapped():
         return "foo"
 
+    registered_task = task_manager.tasks["tests.unit.test_tasks.wrapped"]
+
     assert "foo" == wrapped()
-    assert "wrapped" == task_manager.tasks["wrapped"].name
-    assert "default" == task_manager.tasks["wrapped"].queue
-    assert task_manager.tasks["wrapped"] is wrapped
-    assert task_manager.tasks["wrapped"].func is wrapped.__wrapped__
+    assert "tests.unit.test_tasks.wrapped" == registered_task.name
+    assert "default" == registered_task.queue
+    assert registered_task is wrapped
+    assert registered_task.func is wrapped.__wrapped__
 
 
 def test_task_manager_register(task_manager, mocker):
@@ -139,3 +147,28 @@ def test_task_manager_default_connection(mocker):
     task_manager = tasks.TaskManager()
 
     assert isinstance(task_manager.job_store, postgres.PostgresJobStore)
+
+
+def test_load_task_not_found():
+    with pytest.raises(exceptions.TaskNotFound):
+        tasks.load_task("foobarbaz")
+
+
+def test_load_task_not_a_task():
+    with pytest.raises(exceptions.NotATask):
+        tasks.load_task("json.loads")
+
+
+some_task = None
+
+
+def test_load_task(task_manager):
+    global some_task
+
+    @task_manager.task
+    def task_func():
+        return "foo"
+
+    some_task = task_func
+
+    assert tasks.load_task("tests.unit.test_tasks.some_task") == some_task

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,16 @@
+import pytest
+
+from cabbage import utils
+
+
+def test_load_from_path():
+    loads = utils.load_from_path("json.loads")
+    import json
+
+    assert loads is json.loads
+
+
+@pytest.mark.parametrize("input", ["foobarbaz", "fooobarbaz.loads", "json.foobarbaz"])
+def test_load_from_path_error(input):
+    with pytest.raises(ImportError):
+        utils.load_from_path(input)

--- a/tests/unit/unused_module.py
+++ b/tests/unit/unused_module.py
@@ -1,0 +1,3 @@
+"""
+This module is just here for test_worker.test_import_all
+"""


### PR DESCRIPTION
Fixes #29 

This PR adds 2 cooperating mechanisms for discovering tasks:
- An `import_modules` argument to worker that will import the given modules, ensuring that the tasks in those modules are registered correctly
- The name of the task in the db is now the importable python path of the task, and when the worker encounters a task it doesn't know, it tries to import it on the fly.

This gives us both power and flexibility. Plus, the 2 mecanisms interact: when a task is loaded dynamically, it logs a warning to help you realize you probably have forgotten to put a path in the discovery.