### PR TITLE
Log task result when job is done (#21)

### DIFF
--- a/cabbage/tasks.py
+++ b/cabbage/tasks.py
@@ -49,7 +49,7 @@ class Task:
         else:
             self.name = self.full_path
 
-    def __call__(self, **kwargs: types.JSONValue) -> None:
+    def __call__(self, **kwargs: types.JSONValue) -> Any:
         return self.func(**kwargs)
 
     @property

--- a/cabbage/worker.py
+++ b/cabbage/worker.py
@@ -139,8 +139,9 @@ class Worker:
 
         logger.info("Starting job", extra={"action": "start_job", "job": log_context})
         try:
-            task(**job.task_kwargs)
+            task_result = task(**job.task_kwargs)
         except Exception as e:
+            task_result = None
             log_title = "Job error"
             log_action = "job_error"
             log_level = logging.ERROR
@@ -154,7 +155,7 @@ class Worker:
         finally:
             end_time = log_context["end_timestamp"] = time.time()
             log_context["duration_seconds"] = end_time - start_time
-            extra = {"action": log_action, "job": log_context}
+            extra = {"action": log_action, "job": log_context, "result": task_result}
             logger.log(log_level, log_title, extra=extra, exc_info=exc_info)
 
     def stop(


### PR DESCRIPTION
Closes #21 

Not a whole lot to see :o

The only decision is *where* to put the result. I chose to put in its own key, it could be in the `job` log_context. I don't mind either way :)