### PR TITLE
Instantiate job store

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   global:
   - PGHOST=localhost
   - PGUSER=postgres
+  - PYTEST_ADDOPTS="--cov-append"
 
 matrix:
   include:
@@ -41,7 +42,7 @@ install:
   - tox --notest -e $TOX_ENV
 
 script:
-  - tox -e $TOX_ENV -- --cov-append
+  - tox -e $TOX_ENV
 
 after_success:
 - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,10 @@ matrix:
     env:
       TOX_ENV: check-lint
 
+  - python: 3.7
+    env:
+      TOX_ENV: docs
+
 # Taken from https://github.com/travis-ci/travis-ci/issues/9624
 before_install:
 - sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/*/main/pg_hba.conf

--- a/cabbage/__init__.py
+++ b/cabbage/__init__.py
@@ -1,5 +1,14 @@
+from cabbage import metadata as _metadata_module
 from cabbage.app import App
 from cabbage.postgres import PostgresJobStore
 from cabbage.retry import BaseRetryStrategy, RetryStrategy
 
 __all__ = ["App", "PostgresJobStore", "RetryStrategy", "BaseRetryStrategy"]
+
+
+_metadata = _metadata_module.extract_metadata()
+__author__ = _metadata["author"]
+__author_email__ = _metadata["email"]
+__copyright__ = _metadata["copyright"]
+__url__ = _metadata["url"]
+__version__ = _metadata["version"]

--- a/cabbage/__init__.py
+++ b/cabbage/__init__.py
@@ -1,4 +1,5 @@
 from cabbage.app import App
 from cabbage.postgres import PostgresJobStore
+from cabbage.retry import RetryStrategy
 
-__all__ = ["App", "PostgresJobStore"]
+__all__ = ["App", "PostgresJobStore", "RetryStrategy"]

--- a/cabbage/__init__.py
+++ b/cabbage/__init__.py
@@ -2,8 +2,15 @@ from cabbage import metadata as _metadata_module
 from cabbage.app import App
 from cabbage.postgres import PostgresJobStore
 from cabbage.retry import BaseRetryStrategy, RetryStrategy
+from cabbage.store import BaseJobStore
 
-__all__ = ["App", "PostgresJobStore", "RetryStrategy", "BaseRetryStrategy"]
+__all__ = [
+    "App",
+    "BaseJobStore",
+    "BaseRetryStrategy",
+    "PostgresJobStore",
+    "RetryStrategy",
+]
 
 
 _metadata = _metadata_module.extract_metadata()

--- a/cabbage/__init__.py
+++ b/cabbage/__init__.py
@@ -1,5 +1,5 @@
 from cabbage.app import App
 from cabbage.postgres import PostgresJobStore
-from cabbage.retry import RetryStrategy
+from cabbage.retry import BaseRetryStrategy, RetryStrategy
 
-__all__ = ["App", "PostgresJobStore", "RetryStrategy"]
+__all__ = ["App", "PostgresJobStore", "RetryStrategy", "BaseRetryStrategy"]

--- a/cabbage/app.py
+++ b/cabbage/app.py
@@ -2,7 +2,7 @@ import functools
 import logging
 from typing import Any, Callable, Dict, Iterable, Optional, Set
 
-from cabbage import postgres, store, tasks, testing, worker
+from cabbage import postgres, store, tasks, testing, worker, retry as retry_module
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +70,7 @@ class App:
         _func: Optional[Callable] = None,
         queue: str = "default",
         name: Optional[str] = None,
+        retry: retry_module.RetryValue = False,
     ) -> Callable:
         """
         Declare a function as a task.
@@ -78,7 +79,7 @@ class App:
         """
 
         def _wrap(func: Callable) -> Callable[..., Any]:
-            task = tasks.Task(func, app=self, queue=queue, name=name)
+            task = tasks.Task(func, app=self, queue=queue, name=name, retry=retry)
             self._register(task)
 
             return functools.update_wrapper(task, func)

--- a/cabbage/app.py
+++ b/cabbage/app.py
@@ -54,7 +54,7 @@ class App:
             The longer the timeout, the longer the server will wait idle if, for
             some reason, the postgres LISTEN call doesn't work.
         """
-        self.job_store: store.JobStore
+        self.job_store: store.BaseJobStore
 
         if in_memory:
             self.job_store = testing.InMemoryJobStore()

--- a/cabbage/app.py
+++ b/cabbage/app.py
@@ -2,7 +2,9 @@ import functools
 import logging
 from typing import Any, Callable, Dict, Iterable, Optional, Set
 
-from cabbage import postgres, store, tasks, testing, worker, retry as retry_module
+from cabbage import postgres
+from cabbage import retry as retry_module
+from cabbage import store, tasks, testing, worker
 
 logger = logging.getLogger(__name__)
 

--- a/cabbage/app.py
+++ b/cabbage/app.py
@@ -2,9 +2,8 @@ import functools
 import logging
 from typing import Any, Callable, Dict, Iterable, Optional, Set
 
-from cabbage import postgres
 from cabbage import retry as retry_module
-from cabbage import store, tasks, testing, worker
+from cabbage import store, tasks, worker
 
 logger = logging.getLogger(__name__)
 
@@ -22,19 +21,17 @@ class App:
     def __init__(
         self,
         *,
-        postgres_dsn: str = "",
+        job_store: store.BaseJobStore,
         import_paths: Optional[Iterable[str]] = None,
-        in_memory: bool = False,
         worker_timeout: float = worker.SOCKET_TIMEOUT,
     ):
         """
         Parameters
         ----------
-        postgres_dsn:
-            postgres (libpq) compatible connection string. See specications:
-            https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
-        in_memory:
-            If True, tasks will not be persisted. This is useful for testing only.
+        job_store:
+            Instance of a subclass of :py:class:`BaseJobStore`, typically
+            :py:class:`PostgresJobStore`. It will be responsible for all
+            communications with the database.
         import_paths:
             List of python dotted paths of modules to import, to make sure
             that the workers know about all possible tasks.
@@ -54,14 +51,7 @@ class App:
             The longer the timeout, the longer the server will wait idle if, for
             some reason, the postgres LISTEN call doesn't work.
         """
-        self.job_store: store.BaseJobStore
-
-        if in_memory:
-            self.job_store = testing.InMemoryJobStore()
-        else:
-            connection = postgres.get_connection(dsn=postgres_dsn)
-            self.job_store = postgres.PostgresJobStore(connection=connection)
-
+        self.job_store = job_store
         self.tasks: Dict[str, tasks.Task] = {}
         self.queues: Set[str] = set()
         self.import_paths = import_paths

--- a/cabbage/exceptions.py
+++ b/cabbage/exceptions.py
@@ -1,3 +1,6 @@
+import datetime
+
+
 class CabbageException(Exception):
     pass
 
@@ -12,3 +15,8 @@ class JobError(CabbageException):
 
 class LoadFromPathError(ImportError, CabbageException):
     pass
+
+
+class JobRetry(CabbageException):
+    def __init__(self, scheduled_at: datetime.datetime):
+        self.scheduled_at = scheduled_at

--- a/cabbage/jobs.py
+++ b/cabbage/jobs.py
@@ -36,7 +36,7 @@ class Job:
         default=None, validator=check_aware
     )
     attempts: int = 0
-    job_store: "cabbage.store.JobStore"
+    job_store: "cabbage.store.BaseJobStore"
 
     def defer(self, **task_kwargs: types.JSONValue) -> int:
 

--- a/cabbage/jobs.py
+++ b/cabbage/jobs.py
@@ -35,6 +35,7 @@ class Job:
     scheduled_at: Optional[datetime.datetime] = attr.ib(
         default=None, validator=check_aware
     )
+    attempts: int = 0
     job_store: "cabbage.store.JobStore"
 
     def defer(self, **task_kwargs: types.JSONValue) -> int:

--- a/cabbage/metadata.py
+++ b/cabbage/metadata.py
@@ -1,0 +1,17 @@
+from typing import Mapping
+
+import importlib_metadata
+
+
+def extract_metadata() -> Mapping[str, str]:
+
+    # Backport of Python 3.8's future importlib.metadata()
+    metadata = importlib_metadata.metadata("cabbage")
+
+    return {
+        "author": metadata["Author"],
+        "email": metadata["Author-email"],
+        "copyright": metadata["License"],
+        "url": metadata["Home-page"],
+        "version": metadata["Version"],
+    }

--- a/cabbage/postgres.py
+++ b/cabbage/postgres.py
@@ -1,3 +1,4 @@
+import datetime
 import select
 from typing import Iterable, Iterator, Optional
 
@@ -28,7 +29,7 @@ WHERE status = 'doing'
 """
 
 finish_job_sql = """
-SELECT cabbage_finish_job(%(job_id)s, %(status)s);
+SELECT cabbage_finish_job(%(job_id)s, %(status)s, %(scheduled_at)s);
 """
 
 listen_queue_raw_sql = """
@@ -117,11 +118,17 @@ def get_stalled_jobs(
 
 
 def finish_job(
-    connection: psycopg2._psycopg.connection, job_id: int, status: str
+    connection: psycopg2._psycopg.connection,
+    job_id: int,
+    status: str,
+    scheduled_at: Optional[datetime.datetime] = None,
 ) -> None:
     with connection:
         with connection.cursor() as cursor:
-            cursor.execute(finish_job_sql, {"job_id": job_id, "status": status})
+            cursor.execute(
+                finish_job_sql,
+                {"job_id": job_id, "status": status, "scheduled_at": scheduled_at},
+            )
 
 
 def listen_queues(
@@ -174,10 +181,18 @@ class PostgresJobStore(store.JobStore):
         for job_dict in job_dicts:
             yield jobs.Job(job_store=self, **job_dict)  # type: ignore
 
-    def finish_job(self, job: jobs.Job, status: jobs.Status) -> None:
+    def finish_job(
+        self,
+        job: jobs.Job,
+        status: jobs.Status,
+        scheduled_at: Optional[datetime.datetime] = None,
+    ) -> None:
         assert job.id
         return finish_job(
-            connection=self.connection, job_id=job.id, status=status.value
+            connection=self.connection,
+            job_id=job.id,
+            status=status.value,
+            scheduled_at=scheduled_at,
         )
 
     def listen_for_jobs(self, queues: Optional[Iterable[str]] = None) -> None:

--- a/cabbage/postgres.py
+++ b/cabbage/postgres.py
@@ -1,6 +1,6 @@
 import datetime
 import select
-from typing import Iterable, Iterator, Optional
+from typing import Any, Iterable, Iterator, Optional
 
 import psycopg2
 from psycopg2 import extras, sql
@@ -40,9 +40,8 @@ listen_any_queue = "cabbage_any_queue"
 listen_queue_pattern = "cabbage_queue#{queue}"
 
 
-def get_connection(**kwargs) -> psycopg2._psycopg.connection:
-    kwargs.setdefault("dsn", "")
-    return psycopg2.connect(**kwargs)
+def get_connection(*args, **kwargs) -> psycopg2._psycopg.connection:
+    return psycopg2.connect(*args, **kwargs)
 
 
 def init_pg_extensions() -> None:
@@ -158,8 +157,19 @@ init_pg_extensions()
 
 
 class PostgresJobStore(store.BaseJobStore):
-    def __init__(self, connection: Optional[psycopg2._psycopg.connection] = None):
-        self.connection = connection or get_connection()
+    """
+    A PostgresJobStore uses psycopg2 to establish a synchronous
+    connection to a Postgres database.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        """
+        Parameters are passed to :py:func:`psycopg2.connect`
+        (see the documentation_)
+
+        .. _documentation: http://initd.org/psycopg/docs/module.html#psycopg2.connect
+        """
+        self.connection = get_connection(*args, **kwargs)
 
     def launch_job(self, job: jobs.Job) -> int:
         return launch_job(connection=self.connection, job=job)

--- a/cabbage/postgres.py
+++ b/cabbage/postgres.py
@@ -158,7 +158,7 @@ init_pg_extensions()
 
 class PostgresJobStore(store.BaseJobStore):
     """
-    A PostgresJobStore uses psycopg2 to establish a synchronous
+    Uses `psycopg2` to establish a synchronous
     connection to a Postgres database.
     """
 

--- a/cabbage/postgres.py
+++ b/cabbage/postgres.py
@@ -157,7 +157,7 @@ def wait_for_jobs(connection: psycopg2._psycopg.connection, timeout: float) -> N
 init_pg_extensions()
 
 
-class PostgresJobStore(store.JobStore):
+class PostgresJobStore(store.BaseJobStore):
     def __init__(self, connection: Optional[psycopg2._psycopg.connection] = None):
         self.connection = connection or get_connection()
 

--- a/cabbage/retry.py
+++ b/cabbage/retry.py
@@ -1,0 +1,43 @@
+import datetime
+from typing import Optional, Union
+
+import attr
+import pendulum
+
+from cabbage import exceptions
+
+
+@attr.dataclass(kw_only=True)
+class RetryStrategy:
+    max_attempts: Optional[int] = None
+    wait: int = 0
+
+    def get_retry_exception(self, attempts: int) -> Optional[exceptions.JobRetry]:
+        schedule_in = self.get_schedule_in(attempts=attempts)
+        if schedule_in is None:
+            return None
+
+        schedule_at = pendulum.now("UTC").add(seconds=schedule_in)
+        return exceptions.JobRetry(schedule_at)
+
+    def get_schedule_in(self, attempts: int) -> Optional[datetime.datetime]:
+        if self.max_attempts and attempts >= self.max_attempts:
+            return None
+
+        return self.wait
+
+
+RetryValue = Union[bool, int, RetryStrategy]
+
+
+def get_retry_strategy(retry: RetryValue) -> Optional[RetryStrategy]:
+    if not retry:
+        return None
+
+    if retry is True:
+        return RetryStrategy()
+
+    if isinstance(retry, int):
+        return RetryStrategy(max_attempts=retry)
+
+    return retry

--- a/cabbage/retry.py
+++ b/cabbage/retry.py
@@ -1,4 +1,3 @@
-import datetime
 from typing import Optional, Union
 
 import attr
@@ -20,7 +19,7 @@ class RetryStrategy:
         schedule_at = pendulum.now("UTC").add(seconds=schedule_in)
         return exceptions.JobRetry(schedule_at)
 
-    def get_schedule_in(self, attempts: int) -> Optional[datetime.datetime]:
+    def get_schedule_in(self, attempts: int) -> Optional[int]:
         if self.max_attempts and attempts >= self.max_attempts:
             return None
 

--- a/cabbage/retry.py
+++ b/cabbage/retry.py
@@ -37,8 +37,8 @@ class BaseRetryStrategy:
         -------
         Optional[int]
             If a job should not be retried, this function should return None.
-            Otherwise, it should return the duration before which the job should
-            be scheduled again, *in seconds*.
+            Otherwise, it should return the duration after which to schedule the
+            new job run, *in seconds*.
         """
         raise NotImplementedError()
 

--- a/cabbage/store.py
+++ b/cabbage/store.py
@@ -4,7 +4,7 @@ from typing import Iterable, Iterator, Optional
 from cabbage import jobs
 
 
-class JobStore:
+class BaseJobStore:
     def launch_job(self, job: jobs.Job) -> int:
         raise NotImplementedError
 

--- a/cabbage/store.py
+++ b/cabbage/store.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import Iterable, Iterator, Optional, Type
 
 from cabbage import jobs, utils
@@ -21,7 +22,12 @@ class JobStore:
     def get_jobs(self, queues: Optional[Iterable[str]]) -> Iterator[jobs.Job]:
         raise NotImplementedError
 
-    def finish_job(self, job: jobs.Job, status: jobs.Status) -> None:
+    def finish_job(
+        self,
+        job: jobs.Job,
+        status: jobs.Status,
+        scheduled_at: Optional[datetime.datetime] = None,
+    ) -> None:
         raise NotImplementedError
 
     def listen_for_jobs(self, queues: Optional[Iterable[str]] = None) -> None:

--- a/cabbage/store.py
+++ b/cabbage/store.py
@@ -1,18 +1,7 @@
 import datetime
-from typing import Iterable, Iterator, Optional, Type
+from typing import Iterable, Iterator, Optional
 
-from cabbage import jobs, utils
-
-
-def load_store_from_path(path: str) -> Type["JobStore"]:
-    """
-    Import the JobStore subclass at the given path, return the class.
-    """
-    job_store_class = utils.load_from_path(path, type)
-
-    assert issubclass(job_store_class, JobStore)
-
-    return job_store_class
+from cabbage import jobs
 
 
 class JobStore:

--- a/cabbage/tasks.py
+++ b/cabbage/tasks.py
@@ -83,3 +83,6 @@ class Task:
             scheduled_at=schedule_at,
             job_store=self.app.job_store,
         )
+
+    def get_retry_exception(self, job: jobs.Job) -> Optional[exceptions.JobRetry]:
+        return None

--- a/cabbage/testing.py
+++ b/cabbage/testing.py
@@ -1,6 +1,6 @@
 import datetime
 from itertools import count
-from typing import Iterable, Iterator, List, Optional, Tuple
+from typing import Iterable, Iterator, List, Optional, Set, Tuple
 
 import attr
 import pendulum
@@ -9,14 +9,34 @@ from cabbage import jobs, store
 
 
 class InMemoryJobStore(store.BaseJobStore):
+    """
+    An InMemoryJobStore may be used for testing only. Tasks are not
+    persisted and will be lost when the process ends.
+
+    While implementing the JobStore interface, it also adds a few
+    methods and attributes to ease testing.
+    """
+
     def __init__(self):
+        """
+        Attributes
+        ----------
+        jobs : List[jobs.Job]
+            Currently running Job objects. They are removed from this
+            list upon completion
+        finished_jobs: List[Tuple[jobs.Job, jobs.Status]]
+            List of finished jobs, with their associate status
+        """
         self.reset()
 
     def reset(self):
+        """
+        Removes anything the store might have, to ensure test independance.
+        """
         self.jobs: List[jobs.Job] = []
         self.finished_jobs: List[Tuple[jobs.Job, jobs.Status]] = []
         self.job_counter = count()
-        self.listening_queues = set()
+        self.listening_queues: Set[str] = set()
         self.listening_all_queues = False
         self.waited = []
 

--- a/cabbage/testing.py
+++ b/cabbage/testing.py
@@ -41,7 +41,12 @@ class InMemoryJobStore(store.JobStore):
         scheduled_at: Optional[datetime.datetime] = None,
     ) -> None:
         self.jobs.remove(job)
-        self.finished_jobs.append((job, status))
+        if status in [jobs.Status.DONE, jobs.Status.ERROR]:
+            self.finished_jobs.append((job, status))
+        else:
+            self.jobs.append(
+                attr.evolve(job, attempts=job.attempts + 1, scheduled_at=scheduled_at)
+            )
 
     def listen_for_jobs(self, queues: Optional[Iterable[str]] = None) -> None:
         if queues is None:

--- a/cabbage/testing.py
+++ b/cabbage/testing.py
@@ -31,7 +31,7 @@ class InMemoryJobStore(store.BaseJobStore):
 
     def reset(self):
         """
-        Removes anything the store might have, to ensure test independance.
+        Removes anything the store contains, to ensure test independance.
         """
         self.jobs: List[jobs.Job] = []
         self.finished_jobs: List[Tuple[jobs.Job, jobs.Status]] = []

--- a/cabbage/testing.py
+++ b/cabbage/testing.py
@@ -8,7 +8,7 @@ import pendulum
 from cabbage import jobs, store
 
 
-class InMemoryJobStore(store.JobStore):
+class InMemoryJobStore(store.BaseJobStore):
     def __init__(self):
         self.reset()
 

--- a/cabbage/testing.py
+++ b/cabbage/testing.py
@@ -1,3 +1,4 @@
+import datetime
 from itertools import count
 from typing import Iterable, Iterator, List, Optional, Tuple
 
@@ -33,7 +34,12 @@ class InMemoryJobStore(store.JobStore):
                 if not job.scheduled_at or job.scheduled_at <= pendulum.now("UTC"):
                     yield job
 
-    def finish_job(self, job: jobs.Job, status: jobs.Status) -> None:
+    def finish_job(
+        self,
+        job: jobs.Job,
+        status: jobs.Status,
+        scheduled_at: Optional[datetime.datetime] = None,
+    ) -> None:
         self.jobs.remove(job)
         self.finished_jobs.append((job, status))
 

--- a/cabbage/worker.py
+++ b/cabbage/worker.py
@@ -79,9 +79,13 @@ class Worker:
             )
 
             status = jobs.Status.ERROR
+            next_attempt_scheduled_at = None
             try:
                 self.run_job(job=job)
                 status = jobs.Status.DONE
+            except exceptions.JobRetry as e:
+                status = jobs.Status.TODO
+                next_attempt_scheduled_at = e.scheduled_at
             except exceptions.JobError:
                 pass
             except exceptions.TaskNotFound as exc:
@@ -90,7 +94,9 @@ class Worker:
                     extra={"action": "task_not_found", "exception": str(exc)},
                 )
             finally:
-                self._job_store.finish_job(job=job, status=status)
+                self._job_store.finish_job(
+                    job=job, status=status, scheduled_at=next_attempt_scheduled_at
+                )
                 logger.debug(
                     "Acknowledged job completion",
                     extra={"action": "finish_task", "status": status, **log_context},
@@ -147,7 +153,12 @@ class Worker:
             log_action = "job_error"
             log_level = logging.ERROR
             exc_info = True
+
+            retry_exception = task.get_retry_exception(job)
+            if retry_exception:
+                raise retry_exception from e
             raise exceptions.JobError() from e
+
         else:
             log_title = "Job success"
             log_action = "job_success"

--- a/cabbage/worker.py
+++ b/cabbage/worker.py
@@ -46,7 +46,7 @@ class Worker:
             import_all(import_paths=import_paths)
 
     @property
-    def _job_store(self) -> store.JobStore:
+    def _job_store(self) -> store.BaseJobStore:
         return self._app.job_store
 
     def run(self, timeout: float = SOCKET_TIMEOUT) -> None:

--- a/cabbage_demo/cabbage_app.py
+++ b/cabbage_demo/cabbage_app.py
@@ -1,6 +1,6 @@
 import cabbage
 
 app = cabbage.App(
-    postgres_dsn="postgresql://postgres@localhost/cabbage",
+    job_store=cabbage.PostgresJobStore("postgresql://postgres@localhost/cabbage"),
     import_paths=["cabbage_demo.tasks"],
 )

--- a/cabbage_demo/client.py
+++ b/cabbage_demo/client.py
@@ -13,3 +13,4 @@ def client():
     tasks.sleep.configure(lock="a").defer(i=2)
     tasks.sleep.configure(lock="a").defer(i=3)
     tasks.sleep.configure(lock="a").defer(i=4)
+    tasks.random_fail.defer()

--- a/cabbage_demo/tasks.py
+++ b/cabbage_demo/tasks.py
@@ -1,3 +1,5 @@
+import random
+
 from cabbage_demo.cabbage_app import app
 
 
@@ -16,3 +18,9 @@ def sleep(i):
 @app.task(queue="sums")
 def sum_plus_one(a, b):
     print(a + b + 1)
+
+
+@app.task(queue="retry", retry=100)
+def random_fail():
+    if random.random() > 0.1:
+        raise Exception("random fail")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,6 +48,7 @@ html_theme = "alabaster"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+# html_static_path = ["_static"]
+html_static_path = []
 
 autoclass_content = "both"

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -91,6 +91,57 @@ The details on the parameters you can use are in the pendulum
 `documentation <https://pendulum.eustace.io/docs/#addition-and-subtraction>`_
 (because we use pendulum under the hood).
 
+Define a retry strategy on a task
+---------------------------------
+
+We sometimes know in advance that a task may fail randomly. For example a task
+fetching resources on another network. You can define a retry strategy on a
+task and cabbage will enforce it.
+Available strategies are:
+
+- Define a number of attempts::
+
+    @app.task(retry=5)
+    def flaky_task():
+        if random.random() > 0.9:
+            raise Exception("Who could have seen this coming?")
+        print("Hello world")
+
+
+- Retry indefinitely::
+
+    @app.task(retry=True)
+    def flaky_task():
+        if random.random() > 0.9:
+            raise Exception("Who could have seen this coming?")
+        print("Hello world")
+
+- You can get a more precise strategy using a RetryStrategy instance::
+
+    from cabbage import RetryStrategy
+
+    @app.task(retry=cabbage.RetryStrategy(max_attempts=10, wait=5))
+    def my_other_task():
+        print("Hello world")
+
+- If you want to go for a fully fledged custom retry strategy, you can implement your own RetryStrategy::
+
+    class MyRetryStrategy(cabbage.RetryStrategy):
+        growth: Optional[str] = "linear"
+
+        def get_schedule_in(self, attempts: int) -> int:
+            if super().get_schedule_in(attempts) is None:
+                return None
+
+            if self.growth == "linear":
+                return self.wait * attempts
+            elif self.growth == "exponential":
+                ...
+
+Note that a job waiting to be retried lives in the database. It will persist across
+app / machine reboots.
+
+
 Add a task middleware
 ---------------------
 

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -124,9 +124,9 @@ Available strategies are:
     def my_other_task():
         print("Hello world")
 
-- If you want to go for a fully fledged custom retry strategy, you can implement your own RetryStrategy::
+- If you want to go for a fully fledged custom retry strategy, you can implement your own retry strategy::
 
-    class MyRetryStrategy(cabbage.RetryStrategy):
+    class MyRetryStrategy(cabbage.BaseRetryStrategy):
         growth: Optional[str] = "linear"
 
         def get_schedule_in(self, attempts: int) -> int:

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -124,7 +124,8 @@ Available strategies are:
     def my_other_task():
         print("Hello world")
 
-- If you want to go for a fully fledged custom retry strategy, you can implement your own retry strategy::
+- If you want to go for a fully fledged custom retry strategy, you can implement your
+  own retry strategy::
 
     class MyRetryStrategy(cabbage.BaseRetryStrategy):
         growth: Optional[str] = "linear"

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -172,7 +172,7 @@ controlled way.
 
 To use it, you can do::
 
-    app = cabbage.App(in_memory=running_tests)
+    app = cabbage.App(job_store=cabbage.testing.InMemoryJobStore())
 
     # Run the jobs your tests created, then stop
     # the worker:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ dispatch tasks.
 Here's an example::
 
     # Make a app in your code
-    app = cabbage.App()
+    app = cabbage.App(job_store=cabbage.PostgresJobStore())
 
     # Then define tasks
     @app.task(queue="sums")

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -2,14 +2,9 @@ API Reference
 =============
 
 .. autoclass:: cabbage.App
-    :members: task
-
-.. autoclass:: cabbage.Task
-
-.. autoclass:: cabbage.Worker
-
-.. autoclass:: cabbage.store.JobStore
 
 .. autoclass:: cabbage.PostgresJobStore
+
+.. autoclass:: cabbage.RetryStrategy
 
 .. autoclass:: cabbage.testing.InMemoryJobStore

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1,10 +1,25 @@
 API Reference
 =============
 
+App
+---
+
 .. autoclass:: cabbage.App
+    :members: task, run_worker
+
+Job stores
+----------
 
 .. autoclass:: cabbage.PostgresJobStore
 
+.. autoclass:: cabbage.testing.InMemoryJobStore
+
+Retry strategies
+----------------
+
+.. automodule:: cabbage.retry
+
 .. autoclass:: cabbage.RetryStrategy
 
-.. autoclass:: cabbage.testing.InMemoryJobStore
+.. autoclass:: cabbage.BaseRetryStrategy
+    :members: get_schedule_in

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -13,6 +13,7 @@ Job stores
 .. autoclass:: cabbage.PostgresJobStore
 
 .. autoclass:: cabbage.testing.InMemoryJobStore
+    :members: reset
 
 Retry strategies
 ----------------

--- a/init.sql
+++ b/init.sql
@@ -54,14 +54,15 @@ BEGIN
 END;
 $$;
 
-CREATE FUNCTION public.cabbage_finish_job(job_id integer, end_status public.cabbage_job_status) RETURNS void
+CREATE FUNCTION public.cabbage_finish_job(job_id integer, end_status public.cabbage_job_status, next_scheduled_at timestamp with time zone) RETURNS void
     LANGUAGE plpgsql
     AS $$
 BEGIN
 	WITH finished_job AS (
 		UPDATE cabbage_jobs
         SET status = end_status,
-            attempts = attempts + 1
+            attempts = attempts + 1,
+            scheduled_at = COALESCE(next_scheduled_at, scheduled_at)
         WHERE id = job_id RETURNING lock
 	)
 	DELETE FROM cabbage_job_locks WHERE object = (SELECT lock FROM finished_job);

--- a/init.sql
+++ b/init.sql
@@ -15,7 +15,8 @@ CREATE TABLE public.cabbage_jobs (
     args jsonb DEFAULT '{}' NOT NULL,
     status public.cabbage_job_status DEFAULT 'todo'::public.cabbage_job_status NOT NULL,
     scheduled_at timestamp with time zone NULL,
-    started_at timestamp with time zone NULL
+    started_at timestamp with time zone NULL,
+    attempts integer DEFAULT 0 NOT NULL
 );
 
 CREATE UNLOGGED TABLE public.cabbage_job_locks (
@@ -58,7 +59,10 @@ CREATE FUNCTION public.cabbage_finish_job(job_id integer, end_status public.cabb
     AS $$
 BEGIN
 	WITH finished_job AS (
-		UPDATE cabbage_jobs SET status = end_status WHERE id = job_id RETURNING lock
+		UPDATE cabbage_jobs
+        SET status = end_status,
+            attempts = attempts + 1
+        WHERE id = job_id RETURNING lock
 	)
 	DELETE FROM cabbage_job_locks WHERE object = (SELECT lock FROM finished_job);
 END;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e .[dev,test,lint,doc]
+-e .[dev,test,lint,docs]

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,9 +49,6 @@ doc =
     sphinx
     sphinx_autodoc_typehints
 
-[bdist_wheel]
-universal = 1
-
 [isort]
 multi_line_output=3
 include_trailing_comma=True

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,8 @@ lint =
     isort
     mypy
 
-doc =
+docs =
+    doc8
     sphinx
     sphinx_autodoc_typehints
 
@@ -60,8 +61,13 @@ not_skip = __init__.py
 [flake8]
 max-line-length = 88
 
+[doc8]
+max-line-length=88
+
 [tool:pytest]
-addopts = --cov-report term-missing --cov-branch --cov-report html --cov-report term --cov=cabbage -vv
+addopts =
+    --cov-report term-missing --cov-branch --cov-report html --cov-report term
+    --cov=cabbage -vv
 
 [mypy-setuptools.*,psycopg2.*,pendulum.*,importlib_metadata.*]
 ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cabbage
-description =
+description = Postgres-based distributed task processing library
 version = 0.1.0
 author = PeopleDoc
 author_email = joachim.jablon@people-doc.com
@@ -66,7 +66,7 @@ max-line-length = 88
 [tool:pytest]
 addopts = --cov-report term-missing --cov-branch --cov-report html --cov-report term --cov=cabbage -vv
 
-[mypy-setuptools.*,psycopg2.*,pendulum.*]
+[mypy-setuptools.*,psycopg2.*,pendulum.*,importlib_metadata.*]
 ignore_missing_imports = True
 
 [coverage:report]

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = cabbage
 description =
 version = 0.1.0
-author = peopledoc
+author = PeopleDoc
 author_email = joachim.jablon@people-doc.com
 url = https://github.com/peopledoc/cabbage
 long_description = file: README.md
@@ -26,6 +26,8 @@ install_requires =
     psycopg2; platform_system!="Darwin"
     attrs
     pendulum
+    # Backport from Python 3.8
+    importlib-metadata
 
 [options.extras_require]
 dev =

--- a/tests/acceptance/test_nominal.py
+++ b/tests/acceptance/test_nominal.py
@@ -8,10 +8,8 @@ import cabbage
 
 
 @pytest.fixture
-def app(connection):
-    app = cabbage.App(worker_timeout=1e-9, postgres_dsn=connection.dsn)
-    yield app
-    app.job_store.connection.close()
+def app(pg_job_store):
+    return cabbage.App(worker_timeout=1e-9, job_store=pg_job_store)
 
 
 def test_nominal(app, kill_own_pid, caplog):

--- a/tests/acceptance/test_nominal.py
+++ b/tests/acceptance/test_nominal.py
@@ -41,11 +41,23 @@ def test_nominal(app, kill_own_pid, caplog):
     def stop_product():
         kill_own_pid(signal.SIGTERM)
 
+    nb_tries = 0
+
+    @app.task(queue="retry", retry=10)
+    def two_fails():
+        nonlocal nb_tries
+        if nb_tries < 2:
+            nb_tries += 1
+            raise Exception("This should fail")
+
+        kill_own_pid(signal.SIGINT)
+
     sum_task.defer(a=5, b=7)
     sum_task.defer(a=3, b=4)
     increment_task.defer(a=3)
     product_task.defer(a=5, b=4)
     stop_product.defer()
+    two_fails.defer()
 
     def stop():
         time.sleep(1)
@@ -64,6 +76,10 @@ def test_nominal(app, kill_own_pid, caplog):
 
     assert sum_results == [12, 7, 4, 5]
     assert product_results == [20]
+
+    assert nb_tries == 0
+    app.run_worker(queues=["retry"])
+    assert nb_tries == 2
 
 
 def test_lock(app, caplog):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from psycopg2 import sql
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
 from cabbage import app as app_module
-from cabbage import jobs, testing, postgres
+from cabbage import jobs, postgres, testing
 
 
 def _execute(cursor, query, *identifiers):

--- a/tests/integration/test_postgres.py
+++ b/tests/integration/test_postgres.py
@@ -218,11 +218,18 @@ def test_finish_job(get_all, job_store):
     assert get_all("cabbage_jobs", "status") == [{"status": "doing"}]
     started_at = get_all("cabbage_jobs", "started_at")[0]["started_at"]
     assert started_at.date() == datetime.datetime.utcnow().date()
+    assert get_all("cabbage_jobs", "attempts") == [{"attempts": 0}]
 
     job_store.finish_job(job=job, status=jobs.Status.DONE)
 
-    assert get_all("cabbage_jobs", "status") == [{"status": "done"}]
-    assert get_all("cabbage_jobs", "started_at") == [{"started_at": started_at}]
+    expected = [
+        {
+            "status": "done",
+            "started_at": started_at,
+            "attempts": 1,
+        }
+    ]
+    assert get_all("cabbage_jobs", "status", "started_at", "attempts") == expected
 
 
 def test_listen_queue(job_store, connection):

--- a/tests/integration/test_postgres.py
+++ b/tests/integration/test_postgres.py
@@ -222,13 +222,7 @@ def test_finish_job(get_all, job_store):
 
     job_store.finish_job(job=job, status=jobs.Status.DONE)
 
-    expected = [
-        {
-            "status": "done",
-            "started_at": started_at,
-            "attempts": 1,
-        }
-    ]
+    expected = [{"status": "done", "started_at": started_at, "attempts": 1}]
     assert get_all("cabbage_jobs", "status", "started_at", "attempts") == expected
 
 

--- a/tests/integration/test_postgres.py
+++ b/tests/integration/test_postgres.py
@@ -36,12 +36,7 @@ def get_all(connection):
     return f
 
 
-@pytest.fixture
-def job_store(connection):
-    return postgres.PostgresJobStore(connection=connection)
-
-
-def test_launch_job(job_store, get_all):
+def test_launch_job(pg_job_store, get_all):
     queue = "marsupilami"
     job = jobs.Job(
         id=0,
@@ -49,9 +44,9 @@ def test_launch_job(job_store, get_all):
         task_name="bob",
         lock="sher",
         task_kwargs={"a": 1, "b": 2},
-        job_store=job_store,
+        job_store=pg_job_store,
     )
-    pk = job_store.launch_job(job=job)
+    pk = pg_job_store.launch_job(job=job)
 
     result = get_all("cabbage_jobs", "id", "args", "status", "lock", "task_name")
     assert result == [
@@ -65,50 +60,50 @@ def test_launch_job(job_store, get_all):
     ]
 
 
-def test_get_jobs(job_store):
-    job_store.launch_job(
+def test_get_jobs(pg_job_store):
+    pg_job_store.launch_job(
         jobs.Job(
             id=0,
             queue="queue_a",
             task_name="task_1",
             lock="lock_1",
             task_kwargs={"a": "b"},
-            job_store=job_store,
+            job_store=pg_job_store,
         )
     )
     # We won't see this one because of the lock
-    job_store.launch_job(
+    pg_job_store.launch_job(
         jobs.Job(
             id=0,
             queue="queue_a",
             task_name="task_2",
             lock="lock_1",
             task_kwargs={"c": "d"},
-            job_store=job_store,
+            job_store=pg_job_store,
         )
     )
-    job_store.launch_job(
+    pg_job_store.launch_job(
         jobs.Job(
             id=0,
             queue="queue_a",
             task_name="task_3",
             lock="lock_2",
             task_kwargs={"e": "f"},
-            job_store=job_store,
+            job_store=pg_job_store,
         )
     )
     # We won't see this one because of the queue
-    job_store.launch_job(
+    pg_job_store.launch_job(
         jobs.Job(
             id=0,
             queue="queue_b",
             task_name="task_4",
             lock="lock_3",
             task_kwargs={"g": "h"},
-            job_store=job_store,
+            job_store=pg_job_store,
         )
     )
-    job_store.launch_job(
+    pg_job_store.launch_job(
         jobs.Job(
             id=0,
             queue="queue_a",
@@ -116,11 +111,11 @@ def test_get_jobs(job_store):
             lock="lock_5",
             task_kwargs={"i": "j"},
             scheduled_at=pendulum.datetime(2000, 1, 1),
-            job_store=job_store,
+            job_store=pg_job_store,
         )
     )
     # We won't see this one because of the scheduled date
-    job_store.launch_job(
+    pg_job_store.launch_job(
         jobs.Job(
             id=0,
             queue="queue_a",
@@ -128,11 +123,11 @@ def test_get_jobs(job_store):
             lock="lock_6",
             task_kwargs={"k": "l"},
             scheduled_at=pendulum.datetime(2050, 1, 1),
-            job_store=job_store,
+            job_store=pg_job_store,
         )
     )
 
-    result = list(job_store.get_jobs(queues=["queue_a"]))
+    result = list(pg_job_store.get_jobs(queues=["queue_a"]))
 
     t1, t2, t3 = result
     assert result == [
@@ -142,7 +137,7 @@ def test_get_jobs(job_store):
             lock="lock_1",
             task_name="task_1",
             queue="queue_a",
-            job_store=job_store,
+            job_store=pg_job_store,
         ),
         jobs.Job(
             id=t2.id,
@@ -150,7 +145,7 @@ def test_get_jobs(job_store):
             lock="lock_2",
             task_name="task_3",
             queue="queue_a",
-            job_store=job_store,
+            job_store=pg_job_store,
         ),
         jobs.Job(
             id=t3.id,
@@ -159,80 +154,84 @@ def test_get_jobs(job_store):
             lock="lock_5",
             task_kwargs={"i": "j"},
             scheduled_at=pendulum.datetime(2000, 1, 1),
-            job_store=job_store,
+            job_store=pg_job_store,
         ),
     ]
 
 
-def test_get_stalled_jobs(connection, get_all, job_store):
-    job_store.launch_job(
+def test_get_stalled_jobs(get_all, pg_job_store):
+    pg_job_store.launch_job(
         jobs.Job(
             id=0,
             queue="queue_a",
             task_name="task_1",
             lock="lock_1",
             task_kwargs={"a": "b"},
-            job_store=job_store,
+            job_store=pg_job_store,
         )
     )
     job_id = list(get_all("cabbage_jobs", "id"))[0]["id"]
 
     # No started job
-    assert list(job_store.get_stalled_jobs(nb_seconds=3600)) == []
+    assert list(pg_job_store.get_stalled_jobs(nb_seconds=3600)) == []
 
     # We start a job and fake its `started_at`
-    job = next(job_store.get_jobs(queues=["queue_a"]))
-    with connection.cursor() as cursor:
+    job = next(pg_job_store.get_jobs(queues=["queue_a"]))
+    with pg_job_store.connection.cursor() as cursor:
         cursor.execute(
             f"UPDATE cabbage_jobs SET started_at=NOW() - INTERVAL '30 minutes' "
             f"WHERE id={job_id}"
         )
 
     # Nb_seconds parameter
-    assert list(job_store.get_stalled_jobs(nb_seconds=3600)) == []
-    assert list(job_store.get_stalled_jobs(nb_seconds=1800)) == [job]
+    assert list(pg_job_store.get_stalled_jobs(nb_seconds=3600)) == []
+    assert list(pg_job_store.get_stalled_jobs(nb_seconds=1800)) == [job]
 
     # Queue parameter
-    assert list(job_store.get_stalled_jobs(nb_seconds=1800, queue="queue_a")) == [job]
-    assert list(job_store.get_stalled_jobs(nb_seconds=1800, queue="queue_b")) == []
-    # Task name parameter
-    assert list(job_store.get_stalled_jobs(nb_seconds=1800, task_name="task_1")) == [
+    assert list(pg_job_store.get_stalled_jobs(nb_seconds=1800, queue="queue_a")) == [
         job
     ]
-    assert list(job_store.get_stalled_jobs(nb_seconds=1800, task_name="task_2")) == []
+    assert list(pg_job_store.get_stalled_jobs(nb_seconds=1800, queue="queue_b")) == []
+    # Task name parameter
+    assert list(pg_job_store.get_stalled_jobs(nb_seconds=1800, task_name="task_1")) == [
+        job
+    ]
+    assert (
+        list(pg_job_store.get_stalled_jobs(nb_seconds=1800, task_name="task_2")) == []
+    )
 
 
-def test_finish_job(get_all, job_store):
-    job_store.launch_job(
+def test_finish_job(get_all, pg_job_store):
+    pg_job_store.launch_job(
         jobs.Job(
             id=0,
             queue="queue_a",
             task_name="task_1",
             lock="lock_1",
             task_kwargs={"a": "b"},
-            job_store=job_store,
+            job_store=pg_job_store,
         )
     )
-    job = next(job_store.get_jobs(queues=["queue_a"]))
+    job = next(pg_job_store.get_jobs(queues=["queue_a"]))
 
     assert get_all("cabbage_jobs", "status") == [{"status": "doing"}]
     started_at = get_all("cabbage_jobs", "started_at")[0]["started_at"]
     assert started_at.date() == datetime.datetime.utcnow().date()
     assert get_all("cabbage_jobs", "attempts") == [{"attempts": 0}]
 
-    job_store.finish_job(job=job, status=jobs.Status.DONE)
+    pg_job_store.finish_job(job=job, status=jobs.Status.DONE)
 
     expected = [{"status": "done", "started_at": started_at, "attempts": 1}]
     assert get_all("cabbage_jobs", "status", "started_at", "attempts") == expected
 
 
-def test_listen_queue(job_store, connection):
+def test_listen_queue(pg_job_store):
     queue = "".join(random.choices(string.ascii_letters, k=10))
     queue_full_name = f"cabbage_queue#{queue}"
-    job_store.listen_for_jobs(queues=[queue])
-    connection.commit()
+    pg_job_store.listen_for_jobs(queues=[queue])
+    pg_job_store.connection.commit()
 
-    with connection.cursor() as cursor:
+    with pg_job_store.connection.cursor() as cursor:
         cursor.execute(
             """SELECT COUNT(*) FROM pg_listening_channels()
                           WHERE pg_listening_channels = %s""",
@@ -241,11 +240,11 @@ def test_listen_queue(job_store, connection):
         assert cursor.fetchone()[0] == 1
 
 
-def test_listen_all_queue(job_store, connection):
-    job_store.listen_for_jobs()
-    connection.commit()
+def test_listen_all_queue(pg_job_store, connection):
+    pg_job_store.listen_for_jobs()
+    pg_job_store.connection.commit()
 
-    with connection.cursor() as cursor:
+    with pg_job_store.connection.cursor() as cursor:
         cursor.execute(
             """SELECT COUNT(*) FROM pg_listening_channels()
                           WHERE pg_listening_channels = 'cabbage_any_queue'"""
@@ -268,16 +267,13 @@ def test_enum_synced(connection):
         assert pg_values == python_values
 
 
-def test_wait_for_jobs(job_store):
+def test_wait_for_jobs(pg_job_store, connection_params):
 
-    job_store.listen_for_jobs()
+    pg_job_store.listen_for_jobs()
 
     def stop():
-        connection = postgres.get_connection(
-            **job_store.connection.get_dsn_parameters()
-        )
         try:
-            inner_job_store = postgres.PostgresJobStore(connection=connection)
+            inner_job_store = postgres.PostgresJobStore(**connection_params)
 
             time.sleep(0.5)
             inner_job_store.launch_job(
@@ -291,13 +287,13 @@ def test_wait_for_jobs(job_store):
                 )
             )
         finally:
-            connection.close()
+            inner_job_store.connection.close()
 
     thread = threading.Thread(target=stop)
     thread.start()
 
     before = time.perf_counter()
-    job_store.wait_for_jobs(timeout=3)
+    pg_job_store.wait_for_jobs(timeout=3)
     after = time.perf_counter()
 
     # If we wait less than 1 sec, it means the wait didn't reach the timeout.

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -4,7 +4,14 @@ import pytest
 from cabbage import jobs
 
 
-def test_job_get_context(job_store):
+@pytest.mark.parametrize("scheduled_at,context_scheduled_at", [
+    (
+        pendulum.datetime(2000, 1, 1, tz="Europe/Paris"),
+        "2000-01-01T00:00:00+01:00",
+    ),
+    (None, None),
+])
+def test_job_get_context(job_store, scheduled_at, context_scheduled_at):
 
     job = jobs.Job(
         id=12,
@@ -12,8 +19,9 @@ def test_job_get_context(job_store):
         lock="sher",
         task_name="mytask",
         task_kwargs={"a": "b"},
-        scheduled_at=pendulum.datetime(2000, 1, 1, tz="Europe/Paris"),
+        scheduled_at=scheduled_at,
         job_store=job_store,
+        attempts=42,
     )
 
     assert job.get_context() == {
@@ -22,28 +30,8 @@ def test_job_get_context(job_store):
         "lock": "sher",
         "task_name": "mytask",
         "task_kwargs": {"a": "b"},
-        "scheduled_at": "2000-01-01T00:00:00+01:00",
-    }
-
-
-def test_job_get_context_without_scheduled_at(job_store):
-
-    job = jobs.Job(
-        id=12,
-        queue="marsupilami",
-        lock="sher",
-        task_name="mytask",
-        task_kwargs={"a": "b"},
-        job_store=job_store,
-    )
-
-    assert job.get_context() == {
-        "id": 12,
-        "queue": "marsupilami",
-        "lock": "sher",
-        "task_name": "mytask",
-        "task_kwargs": {"a": "b"},
-        "scheduled_at": None,
+        "scheduled_at": context_scheduled_at,
+        "attempts": 42,
     }
 
 

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -4,13 +4,13 @@ import pytest
 from cabbage import jobs
 
 
-@pytest.mark.parametrize("scheduled_at,context_scheduled_at", [
-    (
-        pendulum.datetime(2000, 1, 1, tz="Europe/Paris"),
-        "2000-01-01T00:00:00+01:00",
-    ),
-    (None, None),
-])
+@pytest.mark.parametrize(
+    "scheduled_at,context_scheduled_at",
+    [
+        (pendulum.datetime(2000, 1, 1, tz="Europe/Paris"), "2000-01-01T00:00:00+01:00"),
+        (None, None),
+    ],
+)
 def test_job_get_context(job_store, scheduled_at, context_scheduled_at):
 
     job = jobs.Job(

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -1,0 +1,45 @@
+import pendulum
+import pytest
+
+from cabbage import exceptions
+from cabbage import retry as retry_module
+
+
+@pytest.mark.parametrize(
+    "retry, expected_strategy",
+    [
+        (None, None),
+        (12, retry_module.RetryStrategy(max_attempts=12)),
+        (True, retry_module.RetryStrategy()),
+        (
+            retry_module.RetryStrategy(max_attempts=42),
+            retry_module.RetryStrategy(max_attempts=42),
+        ),
+    ],
+)
+def test_get_retry_strategy(retry, expected_strategy):
+    assert expected_strategy == retry_module.get_retry_strategy(retry)
+
+
+@pytest.mark.parametrize(
+    "attempts, schedule_in", [(1, 5), (9, 5), (10, None), (11, None), (100, None)]
+)
+def test_get_schedule_in(attempts, schedule_in):
+    strategy = retry_module.RetryStrategy(max_attempts=10, wait=5)
+    assert strategy.get_schedule_in(attempts=attempts) == schedule_in
+
+
+def test_get_retry_exception_returns_none():
+    strategy = retry_module.RetryStrategy(max_attempts=10, wait=5)
+    assert strategy.get_retry_exception(attempts=100) is None
+
+
+def test_get_retry_exception_returns():
+    strategy = retry_module.RetryStrategy(max_attempts=10, wait=5)
+
+    now = pendulum.datetime(2000, 1, 1, tz="UTC")
+    expected = pendulum.datetime(2000, 1, 1, 0, 0, 5, tz="UTC")
+    with pendulum.test(now):
+        exc = strategy.get_retry_exception(attempts=1)
+        assert isinstance(exc, exceptions.JobRetry)
+        assert exc.scheduled_at == expected

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -1,7 +1,0 @@
-from cabbage import store, testing
-
-
-def test_load_store_from_path():
-    store_class = store.load_store_from_path("cabbage.testing.InMemoryJobStore")
-
-    assert store_class is testing.InMemoryJobStore

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -93,6 +93,23 @@ def test_task_configure_schedule_in_and_schedule_at(app):
         )
 
 
+def test_task_get_retry_exception_none(app):
+    task = tasks.Task(task_func, app=app, queue="queue")
+    job = task.configure()
+
+    assert task.get_retry_exception(job) is None
+
+
+def test_task_get_retry_exception(app, mocker):
+    mock = mocker.patch("cabbage.retry.RetryStrategy.get_retry_exception")
+
+    task = tasks.Task(task_func, app=app, queue="queue", retry=10)
+    job = task.configure()
+
+    assert task.get_retry_exception(job) is mock.return_value
+    mock.assert_called_with(0)
+
+
 def test_load_task_not_found():
     with pytest.raises(exceptions.TaskNotFound):
         tasks.load_task("foobarbaz")

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ extras =
     test
 passenv =
     {integration,acceptance}-tests: PG*
+    tests: PYTEST_ADDOPTS
 commands =
     pip freeze -l
     unit-tests: pytest tests/unit {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -34,3 +34,11 @@ extras =
 commands =
     isort -y
     black .
+
+
+[testenv:docs]
+extras =
+    docs
+commands =
+    sphinx-build -W docs docs/_build/html {posargs}
+    doc8 docs


### PR DESCRIPTION
Based on #49

This PR:
- Finally makes up cabbages's mind regarding App instanciation: it takes an instance of JobStore
- Adds __version__ and other metadata at the top level
- Add building of the docs in the CI, we realized it was missing
