### PR TITLE
Reorganize timeout

### DIFF
--- a/cabbage/app.py
+++ b/cabbage/app.py
@@ -23,7 +23,6 @@ class App:
         *,
         job_store: store.BaseJobStore,
         import_paths: Optional[Iterable[str]] = None,
-        worker_timeout: float = worker.SOCKET_TIMEOUT,
     ):
         """
         Parameters
@@ -43,19 +42,11 @@ class App:
             A :py:func:`App.task` that has a custom "name" parameter, that is not
             imported and whose module path is not in this list will
             fail to run.
-        worker_timeout:
-            This parameter should generally not be changed.
-            It indicates how long cabbage waits (in seconds) between
-            renewing the socket `select` calls when waiting for tasks.
-            The shorter the timeout, the more `select` calls it does.
-            The longer the timeout, the longer the server will wait idle if, for
-            some reason, the postgres LISTEN call doesn't work.
         """
         self.job_store = job_store
         self.tasks: Dict[str, tasks.Task] = {}
         self.queues: Set[str] = set()
         self.import_paths = import_paths
-        self.worker_timeout = worker_timeout
 
     def task(
         self,
@@ -116,4 +107,4 @@ class App:
         if only_once:
             worker.process_jobs_once()
         else:
-            worker.run(timeout=self.worker_timeout)
+            worker.run()

--- a/cabbage/store.py
+++ b/cabbage/store.py
@@ -22,5 +22,5 @@ class BaseJobStore:
     def listen_for_jobs(self, queues: Optional[Iterable[str]] = None) -> None:
         raise NotImplementedError
 
-    def wait_for_jobs(self, timeout: float):
+    def wait_for_jobs(self):
         raise NotImplementedError

--- a/cabbage/store.py
+++ b/cabbage/store.py
@@ -24,3 +24,6 @@ class BaseJobStore:
 
     def wait_for_jobs(self):
         raise NotImplementedError
+
+    def stop(self):
+        raise NotImplementedError

--- a/cabbage/testing.py
+++ b/cabbage/testing.py
@@ -38,7 +38,7 @@ class InMemoryJobStore(store.BaseJobStore):
         self.job_counter = count()
         self.listening_queues: Set[str] = set()
         self.listening_all_queues = False
-        self.waited = []
+        self.waited = False
 
     def launch_job(self, job: jobs.Job) -> int:
         id = next(self.job_counter)
@@ -74,5 +74,5 @@ class InMemoryJobStore(store.BaseJobStore):
         else:
             self.listening_queues.update(queues)
 
-    def wait_for_jobs(self, timeout: float):
-        self.waited.append(timeout)
+    def wait_for_jobs(self):
+        self.waited = True

--- a/cabbage/testing.py
+++ b/cabbage/testing.py
@@ -76,3 +76,6 @@ class InMemoryJobStore(store.BaseJobStore):
 
     def wait_for_jobs(self):
         self.waited = True
+
+    def stop(self):
+        pass

--- a/cabbage/worker.py
+++ b/cabbage/worker.py
@@ -175,6 +175,7 @@ class Worker:
     ) -> None:
         self._stop_requested = True
         log_context = self.log_context
+        self._job_store.stop()
 
         logger.info(
             "Stop requested, waiting for current job to finish",

--- a/cabbage/worker.py
+++ b/cabbage/worker.py
@@ -10,8 +10,6 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:  # coverage: exclude
     from cabbage import app
 
-SOCKET_TIMEOUT: float = 5.0  # seconds
-
 
 def import_all(import_paths: Iterable[str]) -> None:
     """
@@ -49,7 +47,7 @@ class Worker:
     def _job_store(self) -> store.BaseJobStore:
         return self._app.job_store
 
-    def run(self, timeout: float = SOCKET_TIMEOUT) -> None:
+    def run(self) -> None:
         self._job_store.listen_for_jobs(queues=self._queues)
 
         with signals.on_stop(self.stop):
@@ -66,7 +64,7 @@ class Worker:
                 logger.debug(
                     "Waiting for new jobs", extra={"action": "waiting_for_jobs"}
                 )
-                self._job_store.wait_for_jobs(timeout=timeout)
+                self._job_store.wait_for_jobs()
 
     def process_jobs_once(self) -> None:
         for job in self._job_store.get_jobs(self._queues):

--- a/cabbage_demo/cabbage_app.py
+++ b/cabbage_demo/cabbage_app.py
@@ -1,6 +1,6 @@
 import cabbage
 
 app = cabbage.App(
-    job_store=cabbage.PostgresJobStore("postgresql://postgres@localhost/cabbage"),
+    job_store=cabbage.PostgresJobStore(dsn="postgresql://postgres@localhost/cabbage"),
     import_paths=["cabbage_demo.tasks"],
 )

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+from typing import List
 
 # -- Project information -----------------------------------------------------
 
@@ -49,6 +50,6 @@ html_theme = "alabaster"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 # html_static_path = ["_static"]
-html_static_path = []
+html_static_path: List[str] = []
 
 autoclass_content = "both"

--- a/tests/acceptance/test_nominal.py
+++ b/tests/acceptance/test_nominal.py
@@ -9,7 +9,6 @@ import cabbage
 
 @pytest.fixture
 def app(pg_job_store):
-    pg_job_store.socket_timeout = 1e-3
     return cabbage.App(job_store=pg_job_store)
 
 

--- a/tests/acceptance/test_nominal.py
+++ b/tests/acceptance/test_nominal.py
@@ -9,7 +9,8 @@ import cabbage
 
 @pytest.fixture
 def app(pg_job_store):
-    return cabbage.App(worker_timeout=1e-9, job_store=pg_job_store)
+    pg_job_store.socket_timeout = 1e-3
+    return cabbage.App(job_store=pg_job_store)
 
 
 def test_nominal(app, kill_own_pid, caplog):
@@ -101,7 +102,7 @@ def test_lock(app, caplog):
     def launch_worker():
         worker = app._worker()
         workers.append(worker)
-        worker.run(timeout=app.worker_timeout)
+        worker.run()
 
     thread1 = threading.Thread(target=launch_worker)
     thread2 = threading.Thread(target=launch_worker)

--- a/tests/integration/test_postgres.py
+++ b/tests/integration/test_postgres.py
@@ -269,6 +269,7 @@ def test_enum_synced(connection):
 
 def test_wait_for_jobs(pg_job_store, connection_params):
 
+    pg_job_store.socket_timeout = 3
     pg_job_store.listen_for_jobs()
 
     def stop():
@@ -293,7 +294,7 @@ def test_wait_for_jobs(pg_job_store, connection_params):
     thread.start()
 
     before = time.perf_counter()
-    pg_job_store.wait_for_jobs(timeout=3)
+    pg_job_store.wait_for_jobs()
     after = time.perf_counter()
 
     # If we wait less than 1 sec, it means the wait didn't reach the timeout.

--- a/tests/integration/test_wait_stop.py
+++ b/tests/integration/test_wait_stop.py
@@ -1,0 +1,85 @@
+import threading
+import time
+
+from cabbage import App, jobs, postgres
+
+
+def test_wait_for_jobs(pg_job_store, connection_params):
+    """
+    Testing that a new job arriving in the queue interrupts the wait
+    """
+    pg_job_store.socket_timeout = 2
+    pg_job_store.listen_for_jobs()
+
+    def stop():
+        time.sleep(0.5)
+        try:
+            inner_job_store = postgres.PostgresJobStore(**connection_params)
+
+            inner_job_store.launch_job(
+                jobs.Job(
+                    id=0,
+                    queue="yay",
+                    task_name="oh",
+                    lock="sher",
+                    task_kwargs={},
+                    job_store=inner_job_store,
+                )
+            )
+        finally:
+            inner_job_store.connection.close()
+
+    thread = threading.Thread(target=stop)
+    thread.start()
+
+    before = time.perf_counter()
+    pg_job_store.wait_for_jobs()
+    after = time.perf_counter()
+
+    # If we wait less than 1 sec, it means the wait didn't reach the timeout.
+    assert after - before < 1
+
+
+def test_wait_for_jobs_stop_from_signal(pg_job_store, kill_own_pid):
+    """
+    Testing than ctrl+c interrupts the wait
+    """
+    pg_job_store.socket_timeout = 2
+    app = App(job_store=pg_job_store)
+
+    def stop():
+        time.sleep(0.5)
+        kill_own_pid()
+
+    thread = threading.Thread(target=stop)
+    thread.start()
+
+    before = time.perf_counter()
+    app.run_worker()
+    after = time.perf_counter()
+
+    # If we wait less than 1 sec, it means the wait didn't reach the timeout.
+    assert after - before < 1
+
+
+def test_wait_for_jobs_stop_from_pipe(pg_job_store):
+    """
+    Testing than calling job_store.stop() interrupts the wait
+    """
+    # This is a sub-case from above but we never know.
+    pg_job_store.socket_timeout = 2
+    pg_job_store.listen_for_jobs()
+
+    def stop():
+        time.sleep(0.5)
+        pg_job_store.stop()
+
+    thread = threading.Thread(target=stop)
+    thread.start()
+
+    before = time.perf_counter()
+    pg_job_store.wait_for_jobs()
+    after = time.perf_counter()
+
+    # If we wait less than 1 sec, it means the wait didn't reach the timeout.
+    assert after - before < 1

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -71,11 +71,10 @@ def test_app_worker(app, mocker):
 
 def test_app_run_worker(app, mocker):
     run = mocker.patch("cabbage.worker.Worker.run")
-    app.worker_timeout = 42
 
     app.run_worker(queues=["yay"])
 
-    run.assert_called_once_with(timeout=42)
+    run.assert_called_once_with()
 
 
 def test_app_run_worker_only_once(app):

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -17,10 +17,10 @@ def test_run(app):
 
     test_worker = TestWorker(app=app, queues=["marsupilami"])
 
-    test_worker.run(timeout=42)
+    test_worker.run()
 
     assert app.job_store.listening_queues == {"marsupilami"}
-    assert app.job_store.waited == [42, 42]
+    assert app.job_store.waited is True
 
 
 def test_run_all_tasks(app):


### PR DESCRIPTION
Now that the job store is independently instantiated, it makes more sense that the socket timeout is an implementation detail of the store rather than of the whole app. This simplifies a lot of things. Also, reintergrate #43 that was beginning to drift seriously.